### PR TITLE
ch_frb_io changes to support initial RPC work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ INSTALLED_BINARIES=ch-show-intensity-file
 INSTALLED_SCRIPTS=ch-plot-intensity-file
 
 TEST_BINARIES = test-intensity-hdf5-file \
+	test-assembled-chunk-hdf5-file \
 	test-misc \
 	test-network-streams
 
@@ -79,6 +80,9 @@ ch-show-intensity-file: ch-show-intensity-file.cpp $(INCFILES) libch_frb_io.so
 	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io
 
 test-intensity-hdf5-file: test-intensity-hdf5-file.cpp $(INCFILES) libch_frb_io.so
+	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io
+
+test-assembled-chunk-hdf5-file: test-assembled-chunk-hdf5-file.cpp $(INCFILES) libch_frb_io.so
 	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io
 
 test-misc: test-misc.cpp $(INCFILES) libch_frb_io.so

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,10 @@ OFILES = assembled_chunk.o \
 
 CPP += -Ibitshuffle
 
-INCFILES=ch_frb_io.hpp ch_frb_io_internals.hpp assembled_chunk_msgpack.hpp
+INCFILES=ch_frb_io.hpp ch_frb_io_internals.hpp assembled_chunk_msgpack.hpp \
+	bitshuffle/bitshuffle.h bitshuffle/bitshuffle_core.h \
+	bitshuffle/bitshuffle_internals.h bitshuffle/iochain.h
+
 LIBFILES=libch_frb_io.so
 INSTALLED_BINARIES=ch-show-intensity-file
 INSTALLED_SCRIPTS=ch-plot-intensity-file

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -182,7 +182,7 @@ void assembled_chunk::write_hdf5_file(const string &filename)
     g_chunk.write_attribute("isample", this->isample);
 
     // Offset & scale vectors
-    vector<hsize_t> scaleshape = { (hsize_t)constants::nfreq_coarse,
+    vector<hsize_t> scaleshape = { (hsize_t)constants::nfreq_coarse_tot,
                                    (hsize_t)this->nt_coarse };
     g_chunk.write_dataset("scales",  this->scales,  scaleshape);
     g_chunk.write_dataset("offsets", this->offsets, scaleshape);

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -176,7 +176,7 @@ void assembled_chunk::write_hdf5_file(const string &filename)
     g_chunk.write_attribute("nt_per_packet", this->nt_per_packet);
     g_chunk.write_attribute("fpga_counts_per_sample", this->fpga_counts_per_sample);
     g_chunk.write_attribute("nt_coarse", this->nt_coarse);
-    g_chunk.write_attribute("nscales", this->nscale);
+    g_chunk.write_attribute("nscales", this->nscales);
     g_chunk.write_attribute("ndata", this->ndata);
     g_chunk.write_attribute("ichunk", this->ichunk);
     g_chunk.write_attribute("isample", this->isample);

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -182,8 +182,9 @@ void assembled_chunk::write_hdf5_file(const string &filename)
     g_chunk.write_attribute("isample", this->isample);
 
     // Offset & scale vectors
-    vector<hsize_t> scaleshape = { (hsize_t)this->nscales };
-    g_chunk.write_dataset("scales", this->scales, scaleshape);
+    vector<hsize_t> scaleshape = { (hsize_t)constants::nfreq_coarse,
+                                   (hsize_t)this->nt_coarse };
+    g_chunk.write_dataset("scales",  this->scales,  scaleshape);
     g_chunk.write_dataset("offsets", this->offsets, scaleshape);
 
     // Raw data

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <immintrin.h>
+#include "assembled_chunk_msgpack.hpp"
 #include "ch_frb_io_internals.hpp"
 
 using namespace std;
@@ -200,6 +201,22 @@ void assembled_chunk::write_hdf5_file(const string &filename)
     data_dataset = unique_ptr<hdf5_extendable_dataset<uint8_t> > ();
 }
 
+void assembled_chunk::write_msgpack_file(const string &filename)
+{
+    msgpack::sbuffer buffer;
+    shared_ptr<assembled_chunk> shthis(shared_ptr<assembled_chunk>(), this);
+    //msgpack::pack(buffer, shared_from_this());
+    //msgpack::pack(buffer, this);
+    msgpack::pack(buffer, shthis);
+    FILE* f = fopen(filename.c_str(), "w+");
+    int nw = fwrite(buffer.data(), 1, buffer.size(), f);
+    if (nw != buffer.size()) {
+        throw runtime_error("ch_frb_io: failed to write assembled_chunk msgpack file " + filename + string(strerror(errno)));
+    }
+    if (fclose(f)) {
+        throw runtime_error("ch_frb_io: failed to close assembled_chunk msgpack file " + filename + string(strerror(errno)));
+    }
+}
 
 
 }  // namespace ch_frb_io

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -6,7 +6,10 @@
 
 #include <msgpack.hpp>
 
+#include <bitshuffle.h>
+
 #include <ch_frb_io.hpp>
+
 
 /** Code for packing objects into msgpack mesages, and vice verse. **/
 
@@ -14,48 +17,66 @@ namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
 namespace adaptor {
 
+    enum compression_type {
+        comp_none = 0,
+        comp_bitshuffle = 1
+    };
+
 // Place class template specialization here
 template<>
 struct convert<std::shared_ptr<ch_frb_io::assembled_chunk> > {
     msgpack::object const& operator()(msgpack::object const& o,
                                       std::shared_ptr<ch_frb_io::assembled_chunk>& ch) const {
         if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
-        //cout << "convert msgpack object to shared_ptr<assembled_chunk>..." << endl;
-        if (o.via.array.size != 14) throw msgpack::type_error();
+        //std::cout << "convert msgpack object to shared_ptr<assembled_chunk>..." << std::endl;
+        if (o.via.array.size != 16) throw msgpack::type_error();
         msgpack::object* arr = o.via.array.ptr;
 
-        // header string is [0]
+        std::string header         = arr[0].as<std::string>();
         uint8_t version            = arr[1].as<uint8_t>();
         if (version != 1)
-            throw std::runtime_error("ch_frb_io assembled_chunk msgpack version " + std::to_string(version) + ", expected 1");
-        int beam_id                = arr[2].as<int>();
-        int nupfreq                = arr[3].as<int>();
-        int nt_per_packet          = arr[4].as<int>();
-        int fpga_counts_per_sample = arr[5].as<int>();
-        int nt_coarse              = arr[6].as<int>();
-        int nscales                = arr[7].as<int>();
-        int ndata                  = arr[8].as<int>();
-        uint64_t ichunk            = arr[9].as<uint64_t>();
-        uint64_t isample           = arr[10].as<uint64_t>();
+            throw std::runtime_error("ch_frb_io: assembled_chunk msgpack version " + std::to_string(version) + ", expected 1");
+        enum compression_type comp = (enum compression_type)arr[2].as<uint8_t>();
+        if (!((comp == comp_none) || (comp == comp_bitshuffle)))
+            throw std::runtime_error("ch_frb_io: assembled_chunk msgpack compression " + std::to_string(comp) + ", expected 0 or 1");
+        int compressed_size        = arr[3].as<int>();
+        int beam_id                = arr[4].as<int>();
+        int nupfreq                = arr[5].as<int>();
+        int nt_per_packet          = arr[6].as<int>();
+        int fpga_counts_per_sample = arr[7].as<int>();
+        int nt_coarse              = arr[8].as<int>();
+        int nscales                = arr[9].as<int>();
+        int ndata                  = arr[10].as<int>();
+        uint64_t ichunk            = arr[11].as<uint64_t>();
+        uint64_t isample           = arr[12].as<uint64_t>();
 
         ch = ch_frb_io::assembled_chunk::make(beam_id, nupfreq, nt_per_packet, fpga_counts_per_sample, ichunk);
         ch->isample = isample;
 
         if (ch->nt_coarse != nt_coarse)
-            throw std::runtime_error("ch_frb_l1 rpc: assembled_chunk nt_coarse mismatch");
+            throw std::runtime_error("ch_frb_io: assembled_chunk msgpack nt_coarse mismatch");
 
-        if (arr[11].type != msgpack::type::BIN) throw msgpack::type_error();
-        if (arr[12].type != msgpack::type::BIN) throw msgpack::type_error();
         if (arr[13].type != msgpack::type::BIN) throw msgpack::type_error();
+        if (arr[14].type != msgpack::type::BIN) throw msgpack::type_error();
+        if (arr[15].type != msgpack::type::BIN) throw msgpack::type_error();
 
         int nsdata = nscales * sizeof(float);
-        if (arr[11].via.bin.size != nsdata) throw msgpack::type_error();
-        if (arr[12].via.bin.size != nsdata) throw msgpack::type_error();
-        if (arr[13].via.bin.size != ndata ) throw msgpack::type_error();
+        if (arr[13].via.bin.size != nsdata) throw msgpack::type_error();
+        if (arr[14].via.bin.size != nsdata) throw msgpack::type_error();
         
-        memcpy(ch->scales,  arr[11].via.bin.ptr, nsdata);
-        memcpy(ch->offsets, arr[12].via.bin.ptr, nsdata);
-        memcpy(ch->data,    arr[13].via.bin.ptr, ndata);
+        memcpy(ch->scales,  arr[13].via.bin.ptr, nsdata);
+        memcpy(ch->offsets, arr[14].via.bin.ptr, nsdata);
+
+        if (comp == comp_none) {
+            if (arr[15].via.bin.size != ndata ) throw msgpack::type_error();
+            memcpy(ch->data,    arr[15].via.bin.ptr, ndata);
+        } else if (comp == comp_bitshuffle) {
+            if (arr[15].via.bin.size != compressed_size) throw msgpack::type_error();
+            std::cout << "Bitshuffle: decompressing " << compressed_size << " to " << ch->ndata << std::endl;
+            int64_t n = bshuf_decompress_lz4(reinterpret_cast<const void*>(arr[15].via.bin.ptr), ch->data, ch->ndata, 1, 0);
+            if (n != compressed_size)
+                throw std::runtime_error("ch_frb_io: assembled_chunk msgpack bitshuffle decompression failure, code " + std::to_string(n));
+        }
 
         return o;
     }
@@ -66,11 +87,53 @@ struct pack<std::shared_ptr<ch_frb_io::assembled_chunk> > {
     template <typename Stream>
     packer<Stream>& operator()(msgpack::packer<Stream>& o, std::shared_ptr<ch_frb_io::assembled_chunk>  const& ch) const {
         // packing member variables as an array.
-        //cout << "Pack shared_ptr<assembled-chunk> into msgpack object..." << endl;
+        //std::cout << "Pack shared_ptr<assembled-chunk> into msgpack object..." << std::endl;
         uint8_t version = 1;
-        o.pack_array(14);
+        o.pack_array(16);
         o.pack("assembled_chunk in msgpack format");
         o.pack(version);
+
+        uint8_t compression = (uint8_t)comp_none;
+        int data_size = ch->ndata;
+        uint8_t* data = ch->data;
+        uint8_t* freedata = NULL;
+        bool compress = ch->msgpack_bitshuffle;
+        size_t maxsize;
+        if (compress) {
+            compression = (uint8_t)comp_bitshuffle;
+            // compress!
+            maxsize = bshuf_compress_lz4_bound(ch->ndata, 1, 0);
+            std::cout << "bitshuffle: uncompressed size " << ch->ndata << ", max compressed size " << maxsize << std::endl;
+            data = freedata = (uint8_t*)malloc(maxsize);
+            if (!data) {
+                std::cout << "Failed to allocate a buffer to compress an assembled_chunk; writing uncompressed" << std::endl;
+                compression = (uint8_t)comp_none;
+                data = ch->data;
+                compress = false;
+            }
+        }
+        if (compress) {
+            int64_t n = bshuf_compress_lz4(ch->data, data, ch->ndata, 1, 0);
+            if ((n < 0) || (n >= ch->ndata)) {
+                if (n < 0)
+                    std::cout << "bitshuffle compression failed; writing uncompressed" << std::endl;
+                else
+                    std::cout << "bitshuffle compression did not actually compress the data (" + std::to_string(n) + " vs orig " + std::to_string(ch->ndata) + "); writing uncompressed" << std::endl;
+                free(freedata);
+                freedata = NULL;
+                data = ch->data;
+                compression = (uint8_t)comp_none;
+                compress = false;
+            } else {
+                data = (uint8_t*)realloc(data, n);
+                freedata = data;
+                data_size = n;
+                std::cout << "Bitshuffle compressed to " << n << std::endl;
+            }
+        }
+        o.pack(compression);
+        o.pack(data_size);
+
         o.pack(ch->beam_id);
         o.pack(ch->nupfreq);
         o.pack(ch->nt_per_packet);
@@ -89,8 +152,14 @@ struct pack<std::shared_ptr<ch_frb_io::assembled_chunk> > {
         o.pack_bin_body(reinterpret_cast<const char*>(ch->offsets),
                         nscalebytes);
 
-        o.pack_bin(ch->ndata);
-        o.pack_bin_body(reinterpret_cast<const char*>(ch->data), ch->ndata);
+        //o.pack_bin(ch->ndata);
+        //o.pack_bin_body(reinterpret_cast<const char*>(ch->data), ch->ndata);
+        o.pack_bin(data_size);
+        o.pack_bin_body(reinterpret_cast<const char*>(data), data_size);
+        
+        if (freedata)
+            free(freedata);
+
         return o;
     }
 };
@@ -100,7 +169,7 @@ template <>
 struct object_with_zone<std::shared_ptr<ch_frb_io::assembled_chunk> > {
     void operator()(msgpack::object::with_zone& o, std::shared_ptr<ch_frb_io::assembled_chunk>  const& v) const {
         o.type = type::ARRAY;
-        cout << "Convert shared_ptr<assembled_chunk> into msgpack object_with_zone" << endl;
+        std::cout << "Convert shared_ptr<assembled_chunk> into msgpack object_with_zone" << std::endl;
 ...
      */
 

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -1,0 +1,111 @@
+#ifndef _ASSEMBLED_CHUNK_MSGPACK_HPP
+#define _ASSEMBLED_CHUNK_MSGPACK_HPP
+
+#include <vector>
+#include <iostream>
+
+#include <msgpack.hpp>
+
+#include <ch_frb_io.hpp>
+
+/** Code for packing objects into msgpack mesages, and vice verse. **/
+
+namespace msgpack {
+MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
+namespace adaptor {
+
+// Place class template specialization here
+template<>
+struct convert<std::shared_ptr<ch_frb_io::assembled_chunk> > {
+    msgpack::object const& operator()(msgpack::object const& o,
+                                      std::shared_ptr<ch_frb_io::assembled_chunk>& ch) const {
+        if (o.type != msgpack::type::ARRAY) throw msgpack::type_error();
+        //cout << "convert msgpack object to shared_ptr<assembled_chunk>..." << endl;
+        if (o.via.array.size != 14) throw msgpack::type_error();
+        msgpack::object* arr = o.via.array.ptr;
+
+        // header string is [0]
+        uint8_t version            = arr[1].as<uint8_t>();
+        if (version != 1)
+            throw std::runtime_error("ch_frb_io assembled_chunk msgpack version " + std::to_string(version) + ", expected 1");
+        int beam_id                = arr[2].as<int>();
+        int nupfreq                = arr[3].as<int>();
+        int nt_per_packet          = arr[4].as<int>();
+        int fpga_counts_per_sample = arr[5].as<int>();
+        int nt_coarse              = arr[6].as<int>();
+        int nscales                = arr[7].as<int>();
+        int ndata                  = arr[8].as<int>();
+        uint64_t ichunk            = arr[9].as<uint64_t>();
+        uint64_t isample           = arr[10].as<uint64_t>();
+
+        ch = ch_frb_io::assembled_chunk::make(beam_id, nupfreq, nt_per_packet, fpga_counts_per_sample, ichunk);
+        ch->isample = isample;
+
+        if (ch->nt_coarse != nt_coarse)
+            throw std::runtime_error("ch_frb_l1 rpc: assembled_chunk nt_coarse mismatch");
+
+        if (arr[11].type != msgpack::type::BIN) throw msgpack::type_error();
+        if (arr[12].type != msgpack::type::BIN) throw msgpack::type_error();
+        if (arr[13].type != msgpack::type::BIN) throw msgpack::type_error();
+
+        int nsdata = nscales * sizeof(float);
+        if (arr[11].via.bin.size != nsdata) throw msgpack::type_error();
+        if (arr[12].via.bin.size != nsdata) throw msgpack::type_error();
+        if (arr[13].via.bin.size != ndata ) throw msgpack::type_error();
+        
+        memcpy(ch->scales,  arr[11].via.bin.ptr, nsdata);
+        memcpy(ch->offsets, arr[12].via.bin.ptr, nsdata);
+        memcpy(ch->data,    arr[13].via.bin.ptr, ndata);
+
+        return o;
+    }
+};
+
+template<>
+struct pack<std::shared_ptr<ch_frb_io::assembled_chunk> > {
+    template <typename Stream>
+    packer<Stream>& operator()(msgpack::packer<Stream>& o, std::shared_ptr<ch_frb_io::assembled_chunk>  const& ch) const {
+        // packing member variables as an array.
+        //cout << "Pack shared_ptr<assembled-chunk> into msgpack object..." << endl;
+        uint8_t version = 1;
+        o.pack_array(14);
+        o.pack("assembled_chunk in msgpack format");
+        o.pack(version);
+        o.pack(ch->beam_id);
+        o.pack(ch->nupfreq);
+        o.pack(ch->nt_per_packet);
+        o.pack(ch->fpga_counts_per_sample);
+        o.pack(ch->nt_coarse);
+        o.pack(ch->nscales);
+        o.pack(ch->ndata);
+        o.pack(ch->ichunk);
+        o.pack(ch->isample);
+        // PACK FLOATS AS BINARY
+        int nscalebytes = ch->nscales * sizeof(float);
+        o.pack_bin(nscalebytes);
+        o.pack_bin_body(reinterpret_cast<const char*>(ch->scales),
+                        nscalebytes);
+        o.pack_bin(nscalebytes);
+        o.pack_bin_body(reinterpret_cast<const char*>(ch->offsets),
+                        nscalebytes);
+
+        o.pack_bin(ch->ndata);
+        o.pack_bin_body(reinterpret_cast<const char*>(ch->data), ch->ndata);
+        return o;
+    }
+};
+
+    /* Apparently not needed yet?
+template <>
+struct object_with_zone<std::shared_ptr<ch_frb_io::assembled_chunk> > {
+    void operator()(msgpack::object::with_zone& o, std::shared_ptr<ch_frb_io::assembled_chunk>  const& v) const {
+        o.type = type::ARRAY;
+        cout << "Convert shared_ptr<assembled_chunk> into msgpack object_with_zone" << endl;
+...
+     */
+
+} // namespace adaptor
+} // MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS)
+} // namespace msgpack
+
+#endif // _ASSEMBLED_CHUNK_MSGPACK_HPP

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -72,6 +72,27 @@ assembled_chunk_ringbuf::get_ringbuf_snapshot()
     return ring;
 }
 
+void assembled_chunk_ringbuf::get_ringbuf_size(uint64_t* ringbuf_pos,
+                                               uint64_t* ringbuf_size,
+                                               uint64_t* ringbuf_nelements,
+                                               uint64_t* ringbuf_capacity) {
+    pthread_mutex_lock(&this->lock);
+    if (ringbuf_pos)
+        *ringbuf_pos = this->assembled_ringbuf_pos;
+    if (ringbuf_size)
+        *ringbuf_size = this->assembled_ringbuf_size;
+    if (ringbuf_capacity)
+        *ringbuf_capacity = constants::assembled_ringbuf_capacity;
+    if (ringbuf_nelements) {
+        uint64_t n = 0;
+        for (uint64_t i=0; i<constants::assembled_ringbuf_capacity; i++)
+            if (assembled_ringbuf[i])
+                n++;
+        *ringbuf_nelements = n;
+    }
+    pthread_mutex_unlock(&this->lock);
+}
+
 void assembled_chunk_ringbuf::put_unassembled_packet(const intensity_packet &packet, int64_t *event_counts)
 {
     // We test these pointers instead of 'doneflag' so that we don't need to acquire the lock in every call.

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -52,6 +52,30 @@ assembled_chunk_ringbuf::~assembled_chunk_ringbuf()
     pthread_mutex_destroy(&this->lock);
 }
 
+int assembled_chunk_ringbuf::get_assembled_ringbuf_size()
+{
+    int rtn = 0;
+    pthread_mutex_lock(&this->lock);
+    rtn = this->assembled_ringbuf_size;
+    pthread_mutex_unlock(&this->lock);
+    return rtn;
+}
+
+std::vector<std::shared_ptr<assembled_chunk> >
+assembled_chunk_ringbuf::get_ringbuf_snapshot()
+{
+    std::vector<std::shared_ptr<assembled_chunk> > ring;
+    pthread_mutex_lock(&this->lock);
+    for (int i=0; i<constants::assembled_ringbuf_capacity; i++) {
+        cout << "Chunk " << assembled_ringbuf[i] << endl;
+        if (assembled_ringbuf[i]) {
+            // Here we make a copy of the shared_ptr, thus preserving the chunk
+            ring.push_back(assembled_ringbuf[i]);
+        }
+    }
+    pthread_mutex_unlock(&this->lock);
+    return ring;
+}
 
 void assembled_chunk_ringbuf::put_unassembled_packet(const intensity_packet &packet, int64_t *event_counts)
 {
@@ -139,7 +163,7 @@ shared_ptr<assembled_chunk> assembled_chunk_ringbuf::get_assembled_chunk()
 	if (assembled_ringbuf_size > 0) {
 	    int i = assembled_ringbuf_pos % constants::assembled_ringbuf_capacity;
 	    shared_ptr<assembled_chunk> chunk = assembled_ringbuf[i];
-	    assembled_ringbuf[i] = shared_ptr<assembled_chunk> ();
+	    //assembled_ringbuf[i] = shared_ptr<assembled_chunk> ();
 
 	    this->assembled_ringbuf_pos++;
 	    this->assembled_ringbuf_size--;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -162,7 +162,6 @@ shared_ptr<assembled_chunk> assembled_chunk_ringbuf::get_assembled_chunk()
 	if (assembled_ringbuf_size > 0) {
 	    int i = assembled_ringbuf_pos % constants::assembled_ringbuf_capacity;
 	    shared_ptr<assembled_chunk> chunk = assembled_ringbuf[i];
-	    //assembled_ringbuf[i] = shared_ptr<assembled_chunk> ();
 
 	    this->assembled_ringbuf_pos++;
 	    this->assembled_ringbuf_size--;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -52,15 +52,6 @@ assembled_chunk_ringbuf::~assembled_chunk_ringbuf()
     pthread_mutex_destroy(&this->lock);
 }
 
-int assembled_chunk_ringbuf::get_assembled_ringbuf_size()
-{
-    int rtn = 0;
-    pthread_mutex_lock(&this->lock);
-    rtn = this->assembled_ringbuf_size;
-    pthread_mutex_unlock(&this->lock);
-    return rtn;
-}
-
 std::vector<std::shared_ptr<assembled_chunk> >
 assembled_chunk_ringbuf::get_ringbuf_snapshot()
 {

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -67,7 +67,6 @@ assembled_chunk_ringbuf::get_ringbuf_snapshot()
     std::vector<std::shared_ptr<assembled_chunk> > ring;
     pthread_mutex_lock(&this->lock);
     for (int i=0; i<constants::assembled_ringbuf_capacity; i++) {
-        cout << "Chunk " << assembled_ringbuf[i] << endl;
         if (assembled_ringbuf[i]) {
             // Here we make a copy of the shared_ptr, thus preserving the chunk
             ring.push_back(assembled_ringbuf[i]);

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -38,7 +38,7 @@ assembled_chunk_ringbuf::assembled_chunk_ringbuf(const intensity_network_stream:
 
     this->active_chunk0 = this->_make_assembled_chunk(ichunk);
     this->active_chunk1 = this->_make_assembled_chunk(ichunk+1);
-    this->assembled_ringbuf_pos = ichunk;
+    this->assembled_ringbuf_pos  = ichunk;
     this->assembled_ringbuf_size = 0;
 
     pthread_mutex_init(&this->lock, NULL);

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -67,7 +67,7 @@ assembled_chunk_ringbuf::get_ringbuf_snapshot()
     std::vector<std::shared_ptr<assembled_chunk> > ring;
     pthread_mutex_lock(&this->lock);
     for (int i=0; i<constants::assembled_ringbuf_capacity; i++) {
-        cout << "Chunk " << assembled_ringbuf[i] << endl;
+        //cout << "Chunk " << assembled_ringbuf[i] << endl;
         if (assembled_ringbuf[i]) {
             // Here we make a copy of the shared_ptr, thus preserving the chunk
             ring.push_back(assembled_ringbuf[i]);
@@ -87,6 +87,9 @@ void assembled_chunk_ringbuf::put_unassembled_packet(const intensity_packet &pac
     uint64_t packet_ichunk = packet_t0 / constants::nt_per_assembled_chunk;
     uint64_t active_ichunk = assembled_ringbuf_pos + assembled_ringbuf_size;
 
+    cout << "put_unassembled_packet: ichunk " << packet_ichunk 
+         << " vs active_ichunk " << active_ichunk << endl;
+
     if (packet_ichunk >= active_ichunk + 2) {
 	//
 	// If we receive a packet whose timestamps extend past the range of our current
@@ -98,6 +101,7 @@ void assembled_chunk_ringbuf::put_unassembled_packet(const intensity_packet &pac
 	// timestamp.  This is to avoid a situation where a single rogue packet timestamped
 	// in the far future effectively kills the L1 node.
 	//
+        cout << "Flushing chunk: " << active_chunk0 << endl;
 	this->_put_assembled_chunk(active_chunk0, event_counts);
 	active_chunk0 = active_chunk1;
 	active_chunk1 = this->_make_assembled_chunk(active_ichunk+2);
@@ -124,6 +128,8 @@ void assembled_chunk_ringbuf::_put_assembled_chunk(const shared_ptr<assembled_ch
 {
     if (!chunk)
 	throw runtime_error("ch_frb_io: internal error: empty pointer passed to assembled_chunk_ringbuf::_put_unassembled_packet()");
+
+    cout << "Put assembled chunk" << endl;
 	
     pthread_mutex_lock(&this->lock);
 

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -67,7 +67,7 @@ assembled_chunk_ringbuf::get_ringbuf_snapshot()
     std::vector<std::shared_ptr<assembled_chunk> > ring;
     pthread_mutex_lock(&this->lock);
     for (int i=0; i<constants::assembled_ringbuf_capacity; i++) {
-        //cout << "Chunk " << assembled_ringbuf[i] << endl;
+        cout << "Chunk " << assembled_ringbuf[i] << endl;
         if (assembled_ringbuf[i]) {
             // Here we make a copy of the shared_ptr, thus preserving the chunk
             ring.push_back(assembled_ringbuf[i]);
@@ -87,9 +87,6 @@ void assembled_chunk_ringbuf::put_unassembled_packet(const intensity_packet &pac
     uint64_t packet_ichunk = packet_t0 / constants::nt_per_assembled_chunk;
     uint64_t active_ichunk = assembled_ringbuf_pos + assembled_ringbuf_size;
 
-    cout << "put_unassembled_packet: ichunk " << packet_ichunk 
-         << " vs active_ichunk " << active_ichunk << endl;
-
     if (packet_ichunk >= active_ichunk + 2) {
 	//
 	// If we receive a packet whose timestamps extend past the range of our current
@@ -101,7 +98,6 @@ void assembled_chunk_ringbuf::put_unassembled_packet(const intensity_packet &pac
 	// timestamp.  This is to avoid a situation where a single rogue packet timestamped
 	// in the far future effectively kills the L1 node.
 	//
-        cout << "Flushing chunk: " << active_chunk0 << endl;
 	this->_put_assembled_chunk(active_chunk0, event_counts);
 	active_chunk0 = active_chunk1;
 	active_chunk1 = this->_make_assembled_chunk(active_ichunk+2);
@@ -128,8 +124,6 @@ void assembled_chunk_ringbuf::_put_assembled_chunk(const shared_ptr<assembled_ch
 {
     if (!chunk)
 	throw runtime_error("ch_frb_io: internal error: empty pointer passed to assembled_chunk_ringbuf::_put_unassembled_packet()");
-
-    cout << "Put assembled chunk" << endl;
 	
     pthread_mutex_lock(&this->lock);
 

--- a/bitshuffle/bitshuffle.c
+++ b/bitshuffle/bitshuffle.c
@@ -1,0 +1,165 @@
+/*
+ * Bitshuffle - Filter for improving compression of typed binary data.
+ *
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ *
+ */
+
+#include "bitshuffle.h"
+#include "bitshuffle_core.h"
+#include "bitshuffle_internals.h"
+#include "lz4.h"
+
+#include <stdio.h>
+#include <string.h>
+
+
+// Constants.
+// Use fast decompression instead of safe decompression for LZ4.
+#define BSHUF_LZ4_DECOMPRESS_FAST
+
+
+// Macros.
+#define CHECK_ERR_FREE_LZ(count, buf) if (count < 0) {                      \
+    free(buf); return count - 1000; }
+
+
+/* Bitshuffle and compress a single block. */
+int64_t bshuf_compress_lz4_block(ioc_chain *C_ptr, \
+        const size_t size, const size_t elem_size) {
+
+    int64_t nbytes, count;
+    void *tmp_buf_bshuf;
+    void *tmp_buf_lz4;
+    size_t this_iter;
+    const void *in;
+    void *out;
+
+    tmp_buf_bshuf = malloc(size * elem_size);
+    if (tmp_buf_bshuf == NULL) return -1;
+
+    tmp_buf_lz4 = malloc(LZ4_compressBound(size * elem_size));
+    if (tmp_buf_lz4 == NULL){
+        free(tmp_buf_bshuf);
+        return -1;
+    }
+
+
+    in = ioc_get_in(C_ptr, &this_iter);
+    ioc_set_next_in(C_ptr, &this_iter, (void*) ((char*) in + size * elem_size));
+
+    count = bshuf_trans_bit_elem(in, tmp_buf_bshuf, size, elem_size);
+    if (count < 0) {
+        free(tmp_buf_lz4);
+        free(tmp_buf_bshuf);
+        return count;
+    }
+    nbytes = LZ4_compress((const char*) tmp_buf_bshuf, (char*) tmp_buf_lz4, size * elem_size);
+    free(tmp_buf_bshuf);
+    CHECK_ERR_FREE_LZ(nbytes, tmp_buf_lz4);
+
+    out = ioc_get_out(C_ptr, &this_iter);
+    ioc_set_next_out(C_ptr, &this_iter, (void *) ((char *) out + nbytes + 4));
+
+    bshuf_write_uint32_BE(out, nbytes);
+    memcpy((char *) out + 4, tmp_buf_lz4, nbytes);
+
+    free(tmp_buf_lz4);
+
+    return nbytes + 4;
+}
+
+
+/* Decompress and bitunshuffle a single block. */
+int64_t bshuf_decompress_lz4_block(ioc_chain *C_ptr,
+        const size_t size, const size_t elem_size) {
+
+    int64_t nbytes, count;
+    void *out, *tmp_buf;
+    const void *in;
+    size_t this_iter;
+    int32_t nbytes_from_header;
+
+    in = ioc_get_in(C_ptr, &this_iter);
+    nbytes_from_header = bshuf_read_uint32_BE(in);
+    ioc_set_next_in(C_ptr, &this_iter,
+            (void*) ((char*) in + nbytes_from_header + 4));
+
+    out = ioc_get_out(C_ptr, &this_iter);
+    ioc_set_next_out(C_ptr, &this_iter,
+            (void *) ((char *) out + size * elem_size));
+
+    tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+#ifdef BSHUF_LZ4_DECOMPRESS_FAST
+    nbytes = LZ4_decompress_fast((const char*) in + 4, (char*) tmp_buf, size * elem_size);
+    CHECK_ERR_FREE_LZ(nbytes, tmp_buf);
+    if (nbytes != nbytes_from_header) {
+        free(tmp_buf);
+        return -91;
+    }
+#else
+    nbytes = LZ4_decompress_safe((const char*) in + 4, (char *) tmp_buf, nbytes_from_header,
+                                 size * elem_size);
+    CHECK_ERR_FREE_LZ(nbytes, tmp_buf);
+    if (nbytes != size * elem_size) {
+        free(tmp_buf);
+        return -91;
+    }
+    nbytes = nbytes_from_header;
+#endif
+    count = bshuf_untrans_bit_elem(tmp_buf, out, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    nbytes += 4;
+
+    free(tmp_buf);
+    return nbytes;
+}
+
+
+/* ---- Public functions ----
+ *
+ * See header file for description and usage.
+ *
+ */
+
+size_t bshuf_compress_lz4_bound(const size_t size,
+        const size_t elem_size, size_t block_size) {
+
+    size_t bound, leftover;
+
+    if (block_size == 0) {
+        block_size = bshuf_default_block_size(elem_size);
+    }
+    if (block_size % BSHUF_BLOCKED_MULT) return -81;
+
+    // Note that each block gets a 4 byte header.
+    // Size of full blocks.
+    bound = (LZ4_compressBound(block_size * elem_size) + 4) * (size / block_size);
+    // Size of partial blocks, if any.
+    leftover = ((size % block_size) / BSHUF_BLOCKED_MULT) * BSHUF_BLOCKED_MULT;
+    if (leftover) bound += LZ4_compressBound(leftover * elem_size) + 4;
+    // Size of uncompressed data not fitting into any blocks.
+    bound += (size % BSHUF_BLOCKED_MULT) * elem_size;
+    return bound;
+}
+
+
+int64_t bshuf_compress_lz4(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size) {
+    return bshuf_blocked_wrap_fun(&bshuf_compress_lz4_block, in, out, size,
+            elem_size, block_size);
+}
+
+
+int64_t bshuf_decompress_lz4(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size) {
+    return bshuf_blocked_wrap_fun(&bshuf_decompress_lz4_block, in, out, size,
+            elem_size, block_size);
+}
+

--- a/bitshuffle/bitshuffle.h
+++ b/bitshuffle/bitshuffle.h
@@ -1,0 +1,123 @@
+/*
+ * Bitshuffle - Filter for improving compression of typed binary data.
+ *
+ * This file is part of Bitshuffle
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ *
+ *
+ * Header File
+ *
+ * Worker routines return an int64_t which is the number of bytes processed
+ * if positive or an error code if negative.
+ *
+ * Error codes:
+ *      -1    : Failed to allocate memory.
+ *      -11   : Missing SSE.
+ *      -12   : Missing AVX.
+ *      -80   : Input size not a multiple of 8.
+ *      -81   : block_size not multiple of 8.
+ *      -91   : Decompression error, wrong number of bytes processed.
+ *      -1YYY : Error internal to compression routine with error code -YYY.
+ */
+
+
+#ifndef BITSHUFFLE_H
+#define BITSHUFFLE_H
+
+#include <stdlib.h>
+#include "bitshuffle_core.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- bshuf_compress_lz4_bound ----
+ *
+ * Bound on size of data compressed with *bshuf_compress_lz4*.
+ *
+ * Parameters
+ * ----------
+ *  size : number of elements in input
+ *  elem_size : element size of typed data
+ *  block_size : Process in blocks of this many elements. Pass 0 to
+ *  select automatically (recommended).
+ *
+ * Returns
+ * -------
+ *  Bound on compressed data size.
+ *
+ */
+size_t bshuf_compress_lz4_bound(const size_t size,
+        const size_t elem_size, size_t block_size);
+
+
+/* ---- bshuf_compress_lz4 ----
+ *
+ * Bitshuffled and compress the data using LZ4.
+ *
+ * Transpose within elements, in blocks of data of *block_size* elements then
+ * compress the blocks using LZ4.  In the output buffer, each block is prefixed
+ * by a 4 byte integer giving the compressed size of that block.
+ *
+ * Output buffer must be large enough to hold the compressed data.  This could
+ * be in principle substantially larger than the input buffer.  Use the routine
+ * *bshuf_compress_lz4_bound* to get an upper limit.
+ *
+ * Parameters
+ * ----------
+ *  in : input buffer, must be of size * elem_size bytes
+ *  out : output buffer, must be large enough to hold data.
+ *  size : number of elements in input
+ *  elem_size : element size of typed data
+ *  block_size : Process in blocks of this many elements. Pass 0 to
+ *  select automatically (recommended).
+ *
+ * Returns
+ * -------
+ *  number of bytes used in output buffer, negative error-code if failed.
+ *
+ */
+int64_t bshuf_compress_lz4(const void* in, void* out, const size_t size, const size_t
+        elem_size, size_t block_size);
+
+
+/* ---- bshuf_decompress_lz4 ----
+ *
+ * Undo compression and bitshuffling.
+ *
+ * Decompress data then un-bitshuffle it in blocks of *block_size* elements.
+ *
+ * To properly unshuffle bitshuffled data, *size*, *elem_size* and *block_size*
+ * must patch the parameters used to compress the data.
+ *
+ * NOT TO BE USED WITH UNTRUSTED DATA: This routine uses the function
+ * LZ4_decompress_fast from LZ4, which does not protect against maliciously
+ * formed datasets. By modifying the compressed data, this function could be
+ * coerced into leaving the boundaries of the input buffer.
+ *
+ * Parameters
+ * ----------
+ *  in : input buffer
+ *  out : output buffer, must be of size * elem_size bytes
+ *  size : number of elements in input
+ *  elem_size : element size of typed data
+ *  block_size : Process in blocks of this many elements. Pass 0 to
+ *  select automatically (recommended).
+ *
+ * Returns
+ * -------
+ *  number of bytes consumed in *input* buffer, negative error-code if failed.
+ *
+ */
+int64_t bshuf_decompress_lz4(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif  // BITSHUFFLE_H

--- a/bitshuffle/bitshuffle_core.c
+++ b/bitshuffle/bitshuffle_core.c
@@ -1,0 +1,1305 @@
+/*
+ * Bitshuffle - Filter for improving compression of typed binary data.
+ *
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ *
+ */
+
+#include "bitshuffle_core.h"
+#include "bitshuffle_internals.h"
+
+#include <stdio.h>
+#include <string.h>
+
+
+#if defined(__AVX2__) && defined (__SSE2__)
+#define USEAVX2
+#endif
+
+#if defined(__SSE2__)
+#define USESSE2
+#endif
+
+
+// Conditional includes for SSE2 and AVX2.
+#ifdef USEAVX2
+#include <immintrin.h>
+#elif defined USESSE2
+#include <emmintrin.h>
+#endif
+
+
+// Macros.
+#define CHECK_MULT_EIGHT(n) if (n % 8) return -80;
+#define MAX(X,Y) ((X) > (Y) ? (X) : (Y))
+
+
+/* ---- Functions indicating compile time instruction set. ---- */
+
+int bshuf_using_SSE2(void) {
+#ifdef USESSE2
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+
+int bshuf_using_AVX2(void) {
+#ifdef USEAVX2
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+
+/* ---- Worker code not requiring special instruction sets. ----
+ *
+ * The following code does not use any x86 specific vectorized instructions
+ * and should compile on any machine
+ *
+ */
+
+/* Transpose 8x8 bit array packed into a single quadword *x*.
+ * *t* is workspace. */
+#define TRANS_BIT_8X8(x, t) {                                               \
+        t = (x ^ (x >> 7)) & 0x00AA00AA00AA00AALL;                          \
+        x = x ^ t ^ (t << 7);                                               \
+        t = (x ^ (x >> 14)) & 0x0000CCCC0000CCCCLL;                         \
+        x = x ^ t ^ (t << 14);                                              \
+        t = (x ^ (x >> 28)) & 0x00000000F0F0F0F0LL;                         \
+        x = x ^ t ^ (t << 28);                                              \
+    }
+
+
+/* Transpose of an array of arbitrarily typed elements. */
+#define TRANS_ELEM_TYPE(in, out, lda, ldb, type_t) {                        \
+        size_t ii, jj, kk;                                                  \
+        const type_t* in_type = (const type_t*) in;                                 \
+        type_t* out_type = (type_t*) out;                                   \
+        for(ii = 0; ii + 7 < lda; ii += 8) {                                \
+            for(jj = 0; jj < ldb; jj++) {                                   \
+                for(kk = 0; kk < 8; kk++) {                                 \
+                    out_type[jj*lda + ii + kk] =                            \
+                        in_type[ii*ldb + kk * ldb + jj];                    \
+                }                                                           \
+            }                                                               \
+        }                                                                   \
+        for(ii = lda - lda % 8; ii < lda; ii ++) {                          \
+            for(jj = 0; jj < ldb; jj++) {                                   \
+                out_type[jj*lda + ii] = in_type[ii*ldb + jj];                            \
+            }                                                               \
+        }                                                                   \
+    }
+
+
+/* Memory copy with bshuf call signature. For testing and profiling. */
+int64_t bshuf_copy(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+
+    memcpy(out_b, in_b, size * elem_size);
+    return size * elem_size;
+}
+
+
+/* Transpose bytes within elements, starting partway through input. */
+int64_t bshuf_trans_byte_elem_remainder(const void* in, void* out, const size_t size,
+         const size_t elem_size, const size_t start) {
+
+    size_t ii, jj, kk;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+
+    CHECK_MULT_EIGHT(start);
+
+    if (size > start) {
+        // ii loop separated into 2 loops so the compiler can unroll
+        // the inner one.
+        for (ii = start; ii + 7 < size; ii += 8) {
+            for (jj = 0; jj < elem_size; jj++) {
+                for (kk = 0; kk < 8; kk++) {
+                    out_b[jj * size + ii + kk]
+                        = in_b[ii * elem_size + kk * elem_size + jj];
+                }
+            }
+        }
+        for (ii = size - size % 8; ii < size; ii ++) {
+            for (jj = 0; jj < elem_size; jj++) {
+                out_b[jj * size + ii] = in_b[ii * elem_size + jj];
+            }
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Transpose bytes within elements. */
+int64_t bshuf_trans_byte_elem_scal(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    return bshuf_trans_byte_elem_remainder(in, out, size, elem_size, 0);
+}
+
+
+/* Transpose bits within bytes. */
+int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t size,
+         const size_t elem_size, const size_t start_byte) {
+
+    int ii, kk;
+    const uint64_t* in_b = (const uint64_t*) in;
+    uint8_t* out_b = (uint8_t*) out;
+
+    uint64_t x, t;
+
+    size_t nbyte = elem_size * size;
+    size_t nbyte_bitrow = nbyte / 8;
+
+    CHECK_MULT_EIGHT(nbyte);
+    CHECK_MULT_EIGHT(start_byte);
+
+    for (ii = start_byte / 8; ii < nbyte_bitrow; ii ++) {
+        x = in_b[ii];
+        TRANS_BIT_8X8(x, t);
+        for (kk = 0; kk < 8; kk ++) {
+            out_b[kk * nbyte_bitrow + ii] = x;
+            x = x >> 8;
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Transpose bits within bytes. */
+int64_t bshuf_trans_bit_byte_scal(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    return bshuf_trans_bit_byte_remainder(in, out, size, elem_size, 0);
+}
+
+
+/* General transpose of an array, optimized for large element sizes. */
+int64_t bshuf_trans_elem(const void* in, void* out, const size_t lda,
+        const size_t ldb, const size_t elem_size) {
+
+    size_t ii, jj;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+    for(ii = 0; ii < lda; ii++) {
+        for(jj = 0; jj < ldb; jj++) {
+            memcpy(&out_b[(jj*lda + ii) * elem_size],
+                   &in_b[(ii*ldb + jj) * elem_size], elem_size);
+        }
+    }
+    return lda * ldb * elem_size;
+}
+
+
+/* Transpose rows of shuffled bits (size / 8 bytes) within groups of 8. */
+int64_t bshuf_trans_bitrow_eight(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    size_t nbyte_bitrow = size / 8;
+
+    CHECK_MULT_EIGHT(size);
+
+    return bshuf_trans_elem(in, out, 8, elem_size, nbyte_bitrow);
+}
+
+
+/* Transpose bits within elements. */
+int64_t bshuf_trans_bit_elem_scal(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+    void *tmp_buf;
+
+    CHECK_MULT_EIGHT(size);
+
+    tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_elem_scal(in, out, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bit_byte_scal(out, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bitrow_eight(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+
+    return count;
+}
+
+
+/* For data organized into a row for each bit (8 * elem_size rows), transpose
+ * the bytes. */
+int64_t bshuf_trans_byte_bitrow_scal(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    size_t ii, jj, kk, nbyte_row;
+    const char *in_b;
+    char *out_b;
+
+
+    in_b = (const char*) in;
+    out_b = (char*) out;
+
+    nbyte_row = size / 8;
+
+    CHECK_MULT_EIGHT(size);
+
+    for (jj = 0; jj < elem_size; jj++) {
+        for (ii = 0; ii < nbyte_row; ii++) {
+            for (kk = 0; kk < 8; kk++) {
+                out_b[ii * 8 * elem_size + jj * 8 + kk] = \
+                        in_b[(jj * 8 + kk) * nbyte_row + ii];
+            }
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Shuffle bits within the bytes of eight element blocks. */
+int64_t bshuf_shuffle_bit_eightelem_scal(const void* in, void* out, \
+        const size_t size, const size_t elem_size) {
+
+    size_t ii, jj, kk;
+    const char *in_b;
+    char *out_b;
+    uint64_t x, t;
+    size_t nbyte;
+
+
+    CHECK_MULT_EIGHT(size);
+
+    in_b = (const char*) in;
+    out_b = (char*) out;
+
+    nbyte = elem_size * size;
+
+    for (jj = 0; jj < 8 * elem_size; jj += 8) {
+        for (ii = 0; ii + 8 * elem_size - 1 < nbyte; ii += 8 * elem_size) {
+            x = *((uint64_t*) &in_b[ii + jj]);
+            TRANS_BIT_8X8(x, t);
+            for (kk = 0; kk < 8; kk++) {
+                *((uint8_t*) &out_b[ii + jj / 8 + kk * elem_size]) = x;
+                x = x >> 8;
+            }
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Untranspose bits within elements. */
+int64_t bshuf_untrans_bit_elem_scal(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+    void *tmp_buf;
+
+    CHECK_MULT_EIGHT(size);
+
+    tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_bitrow_scal(in, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count =  bshuf_shuffle_bit_eightelem_scal(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+
+    return count;
+}
+
+
+/* ---- Worker code that uses SSE2 ----
+ *
+ * The following code makes use of the SSE2 instruction set and specialized
+ * 16 byte registers. The SSE2 instructions are present on modern x86 
+ * processors. The first Intel processor microarchitecture supporting SSE2 was
+ * Pentium 4 (2000).
+ *
+ */
+
+#ifdef USESSE2
+
+/* Transpose bytes within elements for 16 bit elements. */
+int64_t bshuf_trans_byte_elem_SSE_16(const void* in, void* out, const size_t size) {
+
+    size_t ii;
+    const char *in_b = (const char*) in;
+    char *out_b = (char*) out;
+    __m128i a0, b0, a1, b1;
+
+    for (ii=0; ii + 15 < size; ii += 16) {
+        a0 = _mm_loadu_si128((__m128i *) &in_b[2*ii + 0*16]);
+        b0 = _mm_loadu_si128((__m128i *) &in_b[2*ii + 1*16]);
+
+        a1 = _mm_unpacklo_epi8(a0, b0);
+        b1 = _mm_unpackhi_epi8(a0, b0);
+
+        a0 = _mm_unpacklo_epi8(a1, b1);
+        b0 = _mm_unpackhi_epi8(a1, b1);
+
+        a1 = _mm_unpacklo_epi8(a0, b0);
+        b1 = _mm_unpackhi_epi8(a0, b0);
+
+        a0 = _mm_unpacklo_epi8(a1, b1);
+        b0 = _mm_unpackhi_epi8(a1, b1);
+
+        _mm_storeu_si128((__m128i *) &out_b[0*size + ii], a0);
+        _mm_storeu_si128((__m128i *) &out_b[1*size + ii], b0);
+    }
+    return bshuf_trans_byte_elem_remainder(in, out, size, 2,
+            size - size % 16);
+}
+
+
+/* Transpose bytes within elements for 32 bit elements. */
+int64_t bshuf_trans_byte_elem_SSE_32(const void* in, void* out, const size_t size) {
+
+    size_t ii;
+    const char *in_b;
+    char *out_b;
+    in_b = (const char*) in;
+    out_b = (char*) out;
+    __m128i a0, b0, c0, d0, a1, b1, c1, d1;
+
+    for (ii=0; ii + 15 < size; ii += 16) {
+        a0 = _mm_loadu_si128((__m128i *) &in_b[4*ii + 0*16]);
+        b0 = _mm_loadu_si128((__m128i *) &in_b[4*ii + 1*16]);
+        c0 = _mm_loadu_si128((__m128i *) &in_b[4*ii + 2*16]);
+        d0 = _mm_loadu_si128((__m128i *) &in_b[4*ii + 3*16]);
+
+        a1 = _mm_unpacklo_epi8(a0, b0);
+        b1 = _mm_unpackhi_epi8(a0, b0);
+        c1 = _mm_unpacklo_epi8(c0, d0);
+        d1 = _mm_unpackhi_epi8(c0, d0);
+
+        a0 = _mm_unpacklo_epi8(a1, b1);
+        b0 = _mm_unpackhi_epi8(a1, b1);
+        c0 = _mm_unpacklo_epi8(c1, d1);
+        d0 = _mm_unpackhi_epi8(c1, d1);
+
+        a1 = _mm_unpacklo_epi8(a0, b0);
+        b1 = _mm_unpackhi_epi8(a0, b0);
+        c1 = _mm_unpacklo_epi8(c0, d0);
+        d1 = _mm_unpackhi_epi8(c0, d0);
+
+        a0 = _mm_unpacklo_epi64(a1, c1);
+        b0 = _mm_unpackhi_epi64(a1, c1);
+        c0 = _mm_unpacklo_epi64(b1, d1);
+        d0 = _mm_unpackhi_epi64(b1, d1);
+
+        _mm_storeu_si128((__m128i *) &out_b[0*size + ii], a0);
+        _mm_storeu_si128((__m128i *) &out_b[1*size + ii], b0);
+        _mm_storeu_si128((__m128i *) &out_b[2*size + ii], c0);
+        _mm_storeu_si128((__m128i *) &out_b[3*size + ii], d0);
+    }
+    return bshuf_trans_byte_elem_remainder(in, out, size, 4,
+            size - size % 16);
+}
+
+
+/* Transpose bytes within elements for 64 bit elements. */
+int64_t bshuf_trans_byte_elem_SSE_64(const void* in, void* out, const size_t size) {
+
+    size_t ii;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+    __m128i a0, b0, c0, d0, e0, f0, g0, h0;
+    __m128i a1, b1, c1, d1, e1, f1, g1, h1;
+
+    for (ii=0; ii + 15 < size; ii += 16) {
+        a0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 0*16]);
+        b0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 1*16]);
+        c0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 2*16]);
+        d0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 3*16]);
+        e0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 4*16]);
+        f0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 5*16]);
+        g0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 6*16]);
+        h0 = _mm_loadu_si128((__m128i *) &in_b[8*ii + 7*16]);
+
+        a1 = _mm_unpacklo_epi8(a0, b0);
+        b1 = _mm_unpackhi_epi8(a0, b0);
+        c1 = _mm_unpacklo_epi8(c0, d0);
+        d1 = _mm_unpackhi_epi8(c0, d0);
+        e1 = _mm_unpacklo_epi8(e0, f0);
+        f1 = _mm_unpackhi_epi8(e0, f0);
+        g1 = _mm_unpacklo_epi8(g0, h0);
+        h1 = _mm_unpackhi_epi8(g0, h0);
+
+        a0 = _mm_unpacklo_epi8(a1, b1);
+        b0 = _mm_unpackhi_epi8(a1, b1);
+        c0 = _mm_unpacklo_epi8(c1, d1);
+        d0 = _mm_unpackhi_epi8(c1, d1);
+        e0 = _mm_unpacklo_epi8(e1, f1);
+        f0 = _mm_unpackhi_epi8(e1, f1);
+        g0 = _mm_unpacklo_epi8(g1, h1);
+        h0 = _mm_unpackhi_epi8(g1, h1);
+
+        a1 = _mm_unpacklo_epi32(a0, c0);
+        b1 = _mm_unpackhi_epi32(a0, c0);
+        c1 = _mm_unpacklo_epi32(b0, d0);
+        d1 = _mm_unpackhi_epi32(b0, d0);
+        e1 = _mm_unpacklo_epi32(e0, g0);
+        f1 = _mm_unpackhi_epi32(e0, g0);
+        g1 = _mm_unpacklo_epi32(f0, h0);
+        h1 = _mm_unpackhi_epi32(f0, h0);
+
+        a0 = _mm_unpacklo_epi64(a1, e1);
+        b0 = _mm_unpackhi_epi64(a1, e1);
+        c0 = _mm_unpacklo_epi64(b1, f1);
+        d0 = _mm_unpackhi_epi64(b1, f1);
+        e0 = _mm_unpacklo_epi64(c1, g1);
+        f0 = _mm_unpackhi_epi64(c1, g1);
+        g0 = _mm_unpacklo_epi64(d1, h1);
+        h0 = _mm_unpackhi_epi64(d1, h1);
+
+        _mm_storeu_si128((__m128i *) &out_b[0*size + ii], a0);
+        _mm_storeu_si128((__m128i *) &out_b[1*size + ii], b0);
+        _mm_storeu_si128((__m128i *) &out_b[2*size + ii], c0);
+        _mm_storeu_si128((__m128i *) &out_b[3*size + ii], d0);
+        _mm_storeu_si128((__m128i *) &out_b[4*size + ii], e0);
+        _mm_storeu_si128((__m128i *) &out_b[5*size + ii], f0);
+        _mm_storeu_si128((__m128i *) &out_b[6*size + ii], g0);
+        _mm_storeu_si128((__m128i *) &out_b[7*size + ii], h0);
+    }
+    return bshuf_trans_byte_elem_remainder(in, out, size, 8,
+            size - size % 16);
+}
+
+
+/* Transpose bytes within elements using best SSE algorithm available. */
+int64_t bshuf_trans_byte_elem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    // Trivial cases: power of 2 bytes.
+    switch (elem_size) {
+        case 1:
+            count = bshuf_copy(in, out, size, elem_size);
+            return count;
+        case 2:
+            count = bshuf_trans_byte_elem_SSE_16(in, out, size);
+            return count;
+        case 4:
+            count = bshuf_trans_byte_elem_SSE_32(in, out, size);
+            return count;
+        case 8:
+            count = bshuf_trans_byte_elem_SSE_64(in, out, size);
+            return count;
+    }
+
+    // Worst case: odd number of bytes. Turns out that this is faster for
+    // (odd * 2) byte elements as well (hence % 4).
+    if (elem_size % 4) {
+        count = bshuf_trans_byte_elem_scal(in, out, size, elem_size);
+        return count;
+    }
+
+    // Multiple of power of 2: transpose hierarchically.
+    {
+        size_t nchunk_elem;
+        void* tmp_buf = malloc(size * elem_size);
+        if (tmp_buf == NULL) return -1;
+
+        if ((elem_size % 8) == 0) {
+            nchunk_elem = elem_size / 8;
+            TRANS_ELEM_TYPE(in, out, size, nchunk_elem, int64_t);
+            count = bshuf_trans_byte_elem_SSE_64(out, tmp_buf,
+                    size * nchunk_elem);
+            bshuf_trans_elem(tmp_buf, out, 8, nchunk_elem, size);
+        } else if ((elem_size % 4) == 0) {
+            nchunk_elem = elem_size / 4;
+            TRANS_ELEM_TYPE(in, out, size, nchunk_elem, int32_t);
+            count = bshuf_trans_byte_elem_SSE_32(out, tmp_buf,
+                    size * nchunk_elem);
+            bshuf_trans_elem(tmp_buf, out, 4, nchunk_elem, size);
+        } else {
+            // Not used since scalar algorithm is faster.
+            nchunk_elem = elem_size / 2;
+            TRANS_ELEM_TYPE(in, out, size, nchunk_elem, int16_t);
+            count = bshuf_trans_byte_elem_SSE_16(out, tmp_buf,
+                    size * nchunk_elem);
+            bshuf_trans_elem(tmp_buf, out, 2, nchunk_elem, size);
+        }
+
+        free(tmp_buf);
+        return count;
+    }
+}
+
+
+/* Transpose bits within bytes. */
+int64_t bshuf_trans_bit_byte_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    size_t ii, kk;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+    uint16_t* out_ui16;
+
+    int64_t count;
+
+    size_t nbyte = elem_size * size;
+
+    CHECK_MULT_EIGHT(nbyte);
+
+    __m128i xmm;
+    int32_t bt;
+
+    for (ii = 0; ii + 15 < nbyte; ii += 16) {
+        xmm = _mm_loadu_si128((__m128i *) &in_b[ii]);
+        for (kk = 0; kk < 8; kk++) {
+            bt = _mm_movemask_epi8(xmm);
+            xmm = _mm_slli_epi16(xmm, 1);
+            out_ui16 = (uint16_t*) &out_b[((7 - kk) * nbyte + ii) / 8];
+            *out_ui16 = bt;
+        }
+    }
+    count = bshuf_trans_bit_byte_remainder(in, out, size, elem_size,
+            nbyte - nbyte % 16);
+    return count;
+}
+
+
+/* Transpose bits within elements. */
+int64_t bshuf_trans_bit_elem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    CHECK_MULT_EIGHT(size);
+
+    void* tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_elem_SSE(in, out, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bit_byte_SSE(out, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bitrow_eight(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+
+    return count;
+}
+
+
+/* For data organized into a row for each bit (8 * elem_size rows), transpose
+ * the bytes. */
+int64_t bshuf_trans_byte_bitrow_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    size_t ii, jj;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+
+    CHECK_MULT_EIGHT(size);
+
+    size_t nrows = 8 * elem_size;
+    size_t nbyte_row = size / 8;
+
+    __m128i a0, b0, c0, d0, e0, f0, g0, h0;
+    __m128i a1, b1, c1, d1, e1, f1, g1, h1;
+    __m128 *as, *bs, *cs, *ds, *es, *fs, *gs, *hs;
+
+    for (ii = 0; ii + 7 < nrows; ii += 8) {
+        for (jj = 0; jj + 15 < nbyte_row; jj += 16) {
+            a0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 0)*nbyte_row + jj]);
+            b0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 1)*nbyte_row + jj]);
+            c0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 2)*nbyte_row + jj]);
+            d0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 3)*nbyte_row + jj]);
+            e0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 4)*nbyte_row + jj]);
+            f0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 5)*nbyte_row + jj]);
+            g0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 6)*nbyte_row + jj]);
+            h0 = _mm_loadu_si128((__m128i *) &in_b[(ii + 7)*nbyte_row + jj]);
+
+
+            a1 = _mm_unpacklo_epi8(a0, b0);
+            b1 = _mm_unpacklo_epi8(c0, d0);
+            c1 = _mm_unpacklo_epi8(e0, f0);
+            d1 = _mm_unpacklo_epi8(g0, h0);
+            e1 = _mm_unpackhi_epi8(a0, b0);
+            f1 = _mm_unpackhi_epi8(c0, d0);
+            g1 = _mm_unpackhi_epi8(e0, f0);
+            h1 = _mm_unpackhi_epi8(g0, h0);
+
+
+            a0 = _mm_unpacklo_epi16(a1, b1);
+            b0 = _mm_unpacklo_epi16(c1, d1);
+            c0 = _mm_unpackhi_epi16(a1, b1);
+            d0 = _mm_unpackhi_epi16(c1, d1);
+
+            e0 = _mm_unpacklo_epi16(e1, f1);
+            f0 = _mm_unpacklo_epi16(g1, h1);
+            g0 = _mm_unpackhi_epi16(e1, f1);
+            h0 = _mm_unpackhi_epi16(g1, h1);
+
+
+            a1 = _mm_unpacklo_epi32(a0, b0);
+            b1 = _mm_unpackhi_epi32(a0, b0);
+
+            c1 = _mm_unpacklo_epi32(c0, d0);
+            d1 = _mm_unpackhi_epi32(c0, d0);
+
+            e1 = _mm_unpacklo_epi32(e0, f0);
+            f1 = _mm_unpackhi_epi32(e0, f0);
+
+            g1 = _mm_unpacklo_epi32(g0, h0);
+            h1 = _mm_unpackhi_epi32(g0, h0);
+
+            // We don't have a storeh instruction for integers, so interpret
+            // as a float. Have a storel (_mm_storel_epi64).
+            as = (__m128 *) &a1;
+            bs = (__m128 *) &b1;
+            cs = (__m128 *) &c1;
+            ds = (__m128 *) &d1;
+            es = (__m128 *) &e1;
+            fs = (__m128 *) &f1;
+            gs = (__m128 *) &g1;
+            hs = (__m128 *) &h1;
+
+            _mm_storel_pi((__m64 *) &out_b[(jj + 0) * nrows + ii], *as);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 2) * nrows + ii], *bs);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 4) * nrows + ii], *cs);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 6) * nrows + ii], *ds);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 8) * nrows + ii], *es);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 10) * nrows + ii], *fs);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 12) * nrows + ii], *gs);
+            _mm_storel_pi((__m64 *) &out_b[(jj + 14) * nrows + ii], *hs);
+
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 1) * nrows + ii], *as);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 3) * nrows + ii], *bs);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 5) * nrows + ii], *cs);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 7) * nrows + ii], *ds);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 9) * nrows + ii], *es);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 11) * nrows + ii], *fs);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 13) * nrows + ii], *gs);
+            _mm_storeh_pi((__m64 *) &out_b[(jj + 15) * nrows + ii], *hs);
+        }
+        for (jj = nbyte_row - nbyte_row % 16; jj < nbyte_row; jj ++) {
+            out_b[jj * nrows + ii + 0] = in_b[(ii + 0)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 1] = in_b[(ii + 1)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 2] = in_b[(ii + 2)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 3] = in_b[(ii + 3)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 4] = in_b[(ii + 4)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 5] = in_b[(ii + 5)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 6] = in_b[(ii + 6)*nbyte_row + jj];
+            out_b[jj * nrows + ii + 7] = in_b[(ii + 7)*nbyte_row + jj];
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Shuffle bits within the bytes of eight element blocks. */
+int64_t bshuf_shuffle_bit_eightelem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    CHECK_MULT_EIGHT(size);
+
+    // With a bit of care, this could be written such that such that it is
+    // in_buf = out_buf safe.
+    const char* in_b = (const char*) in;
+    uint16_t* out_ui16 = (uint16_t*) out;
+
+    size_t ii, jj, kk;
+    size_t nbyte = elem_size * size;
+
+    __m128i xmm;
+    int32_t bt;
+
+    if (elem_size % 2) {
+        bshuf_shuffle_bit_eightelem_scal(in, out, size, elem_size);
+    } else {
+        for (ii = 0; ii + 8 * elem_size - 1 < nbyte;
+                ii += 8 * elem_size) {
+            for (jj = 0; jj + 15 < 8 * elem_size; jj += 16) {
+                xmm = _mm_loadu_si128((__m128i *) &in_b[ii + jj]);
+                for (kk = 0; kk < 8; kk++) {
+                    bt = _mm_movemask_epi8(xmm);
+                    xmm = _mm_slli_epi16(xmm, 1);
+                    size_t ind = (ii + jj / 8 + (7 - kk) * elem_size);
+                    out_ui16[ind / 2] = bt;
+                }
+            }
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Untranspose bits within elements. */
+int64_t bshuf_untrans_bit_elem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    CHECK_MULT_EIGHT(size);
+
+    void* tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_bitrow_SSE(in, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count =  bshuf_shuffle_bit_eightelem_SSE(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+
+    return count;
+}
+
+#else // #ifdef USESSE2
+
+
+int64_t bshuf_untrans_bit_elem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_bit_elem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_byte_bitrow_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_bit_byte_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_byte_elem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_byte_elem_SSE_64(const void* in, void* out, const size_t size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_byte_elem_SSE_32(const void* in, void* out, const size_t size) {
+    return -11;
+}
+
+
+int64_t bshuf_trans_byte_elem_SSE_16(const void* in, void* out, const size_t size) {
+    return -11;
+}
+
+
+int64_t bshuf_shuffle_bit_eightelem_SSE(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -11;
+}
+
+
+#endif // #ifdef USESSE2
+
+
+/* ---- Code that requires AVX2. Intel Haswell (2013) and later. ---- */
+
+/* ---- Worker code that uses AVX2 ----
+ *
+ * The following code makes use of the AVX2 instruction set and specialized
+ * 32 byte registers. The AVX2 instructions are present on newer x86
+ * processors. The first Intel processor microarchitecture supporting AVX2 was
+ * Haswell (2013).
+ *
+ */
+
+#ifdef USEAVX2
+
+/* Transpose bits within bytes. */
+int64_t bshuf_trans_bit_byte_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    size_t ii, kk;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+    int32_t* out_i32;
+
+    size_t nbyte = elem_size * size;
+
+    int64_t count;
+
+    __m256i ymm;
+    int32_t bt;
+
+    for (ii = 0; ii + 31 < nbyte; ii += 32) {
+        ymm = _mm256_loadu_si256((__m256i *) &in_b[ii]);
+        for (kk = 0; kk < 8; kk++) {
+            bt = _mm256_movemask_epi8(ymm);
+            ymm = _mm256_slli_epi16(ymm, 1);
+            out_i32 = (int32_t*) &out_b[((7 - kk) * nbyte + ii) / 8];
+            *out_i32 = bt;
+        }
+    }
+    count = bshuf_trans_bit_byte_remainder(in, out, size, elem_size,
+            nbyte - nbyte % 32);
+    return count;
+}
+
+
+/* Transpose bits within elements. */
+int64_t bshuf_trans_bit_elem_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    CHECK_MULT_EIGHT(size);
+
+    void* tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_elem_SSE(in, out, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bit_byte_AVX(out, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count = bshuf_trans_bitrow_eight(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+
+    return count;
+}
+
+
+/* For data organized into a row for each bit (8 * elem_size rows), transpose
+ * the bytes. */
+int64_t bshuf_trans_byte_bitrow_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    size_t hh, ii, jj, kk, mm;
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+
+    CHECK_MULT_EIGHT(size);
+
+    size_t nrows = 8 * elem_size;
+    size_t nbyte_row = size / 8;
+
+    if (elem_size % 4) return bshuf_trans_byte_bitrow_SSE(in, out, size,
+            elem_size);
+
+    __m256i ymm_0[8];
+    __m256i ymm_1[8];
+    __m256i ymm_storeage[8][4];
+
+    for (jj = 0; jj + 31 < nbyte_row; jj += 32) {
+        for (ii = 0; ii + 3 < elem_size; ii += 4) {
+            for (hh = 0; hh < 4; hh ++) {
+
+                for (kk = 0; kk < 8; kk ++){
+                    ymm_0[kk] = _mm256_loadu_si256((__m256i *) &in_b[
+                            (ii * 8 + hh * 8 + kk) * nbyte_row + jj]);
+                }
+
+                for (kk = 0; kk < 4; kk ++){
+                    ymm_1[kk] = _mm256_unpacklo_epi8(ymm_0[kk * 2],
+                            ymm_0[kk * 2 + 1]);
+                    ymm_1[kk + 4] = _mm256_unpackhi_epi8(ymm_0[kk * 2],
+                            ymm_0[kk * 2 + 1]);
+                }
+
+                for (kk = 0; kk < 2; kk ++){
+                    for (mm = 0; mm < 2; mm ++){
+                        ymm_0[kk * 4 + mm] = _mm256_unpacklo_epi16(
+                                ymm_1[kk * 4 + mm * 2],
+                                ymm_1[kk * 4 + mm * 2 + 1]);
+                        ymm_0[kk * 4 + mm + 2] = _mm256_unpackhi_epi16(
+                                ymm_1[kk * 4 + mm * 2],
+                                ymm_1[kk * 4 + mm * 2 + 1]);
+                    }
+                }
+
+                for (kk = 0; kk < 4; kk ++){
+                    ymm_1[kk * 2] = _mm256_unpacklo_epi32(ymm_0[kk * 2],
+                            ymm_0[kk * 2 + 1]);
+                    ymm_1[kk * 2 + 1] = _mm256_unpackhi_epi32(ymm_0[kk * 2],
+                            ymm_0[kk * 2 + 1]);
+                }
+
+                for (kk = 0; kk < 8; kk ++){
+                    ymm_storeage[kk][hh] = ymm_1[kk];
+                }
+            }
+
+            for (mm = 0; mm < 8; mm ++) {
+
+                for (kk = 0; kk < 4; kk ++){
+                    ymm_0[kk] = ymm_storeage[mm][kk];
+                }
+
+                ymm_1[0] = _mm256_unpacklo_epi64(ymm_0[0], ymm_0[1]);
+                ymm_1[1] = _mm256_unpacklo_epi64(ymm_0[2], ymm_0[3]);
+                ymm_1[2] = _mm256_unpackhi_epi64(ymm_0[0], ymm_0[1]);
+                ymm_1[3] = _mm256_unpackhi_epi64(ymm_0[2], ymm_0[3]);
+
+                ymm_0[0] = _mm256_permute2x128_si256(ymm_1[0], ymm_1[1], 32);
+                ymm_0[1] = _mm256_permute2x128_si256(ymm_1[2], ymm_1[3], 32);
+                ymm_0[2] = _mm256_permute2x128_si256(ymm_1[0], ymm_1[1], 49);
+                ymm_0[3] = _mm256_permute2x128_si256(ymm_1[2], ymm_1[3], 49);
+
+                _mm256_storeu_si256((__m256i *) &out_b[
+                        (jj + mm * 2 + 0 * 16) * nrows + ii * 8], ymm_0[0]);
+                _mm256_storeu_si256((__m256i *) &out_b[
+                        (jj + mm * 2 + 0 * 16 + 1) * nrows + ii * 8], ymm_0[1]);
+                _mm256_storeu_si256((__m256i *) &out_b[
+                        (jj + mm * 2 + 1 * 16) * nrows + ii * 8], ymm_0[2]);
+                _mm256_storeu_si256((__m256i *) &out_b[
+                        (jj + mm * 2 + 1 * 16 + 1) * nrows + ii * 8], ymm_0[3]);
+            }
+        }
+    }
+    for (ii = 0; ii < nrows; ii ++ ) {
+        for (jj = nbyte_row - nbyte_row % 32; jj < nbyte_row; jj ++) {
+            out_b[jj * nrows + ii] = in_b[ii * nbyte_row + jj];
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Shuffle bits within the bytes of eight element blocks. */
+int64_t bshuf_shuffle_bit_eightelem_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    CHECK_MULT_EIGHT(size);
+
+    // With a bit of care, this could be written such that such that it is
+    // in_buf = out_buf safe.
+    const char* in_b = (const char*) in;
+    char* out_b = (char*) out;
+
+    size_t ii, jj, kk;
+    size_t nbyte = elem_size * size;
+
+    __m256i ymm;
+    int32_t bt;
+
+    if (elem_size % 4) {
+        return bshuf_shuffle_bit_eightelem_SSE(in, out, size, elem_size);
+    } else {
+        for (jj = 0; jj + 31 < 8 * elem_size; jj += 32) {
+            for (ii = 0; ii + 8 * elem_size - 1 < nbyte;
+                    ii += 8 * elem_size) {
+                ymm = _mm256_loadu_si256((__m256i *) &in_b[ii + jj]);
+                for (kk = 0; kk < 8; kk++) {
+                    bt = _mm256_movemask_epi8(ymm);
+                    ymm = _mm256_slli_epi16(ymm, 1);
+                    size_t ind = (ii + jj / 8 + (7 - kk) * elem_size);
+                    * (int32_t *) &out_b[ind] = bt;
+                }
+            }
+        }
+    }
+    return size * elem_size;
+}
+
+
+/* Untranspose bits within elements. */
+int64_t bshuf_untrans_bit_elem_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+
+    int64_t count;
+
+    CHECK_MULT_EIGHT(size);
+
+    void* tmp_buf = malloc(size * elem_size);
+    if (tmp_buf == NULL) return -1;
+
+    count = bshuf_trans_byte_bitrow_AVX(in, tmp_buf, size, elem_size);
+    CHECK_ERR_FREE(count, tmp_buf);
+    count =  bshuf_shuffle_bit_eightelem_AVX(tmp_buf, out, size, elem_size);
+
+    free(tmp_buf);
+    return count;
+}
+
+
+#else // #ifdef USEAVX2
+
+int64_t bshuf_trans_bit_byte_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -12;
+}
+
+
+int64_t bshuf_trans_bit_elem_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -12;
+}
+
+
+int64_t bshuf_trans_byte_bitrow_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -12;
+}
+
+
+int64_t bshuf_shuffle_bit_eightelem_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -12;
+}
+
+
+int64_t bshuf_untrans_bit_elem_AVX(const void* in, void* out, const size_t size,
+         const size_t elem_size) {
+    return -12;
+}
+
+#endif // #ifdef USEAVX2
+
+
+/* ---- Drivers selecting best instruction set at compile time. ---- */
+
+int64_t bshuf_trans_bit_elem(const void* in, void* out, const size_t size, 
+        const size_t elem_size) {
+
+    int64_t count;
+#ifdef USEAVX2
+    count = bshuf_trans_bit_elem_AVX(in, out, size, elem_size);
+#elif defined(USESSE2)
+    count = bshuf_trans_bit_elem_SSE(in, out, size, elem_size);
+#else
+    count = bshuf_trans_bit_elem_scal(in, out, size, elem_size);
+#endif
+    return count;
+}
+
+
+int64_t bshuf_untrans_bit_elem(const void* in, void* out, const size_t size, 
+        const size_t elem_size) {
+
+    int64_t count;
+#ifdef USEAVX2
+    count = bshuf_untrans_bit_elem_AVX(in, out, size, elem_size);
+#elif defined(USESSE2)
+    count = bshuf_untrans_bit_elem_SSE(in, out, size, elem_size);
+#else
+    count = bshuf_untrans_bit_elem_scal(in, out, size, elem_size);
+#endif
+    return count;
+}
+
+
+/* ---- Wrappers for implementing blocking ---- */
+
+/* Wrap a function for processing a single block to process an entire buffer in
+ * parallel. */
+int64_t bshuf_blocked_wrap_fun(bshufBlockFunDef fun, const void* in, void* out, \
+        const size_t size, const size_t elem_size, size_t block_size) {
+
+    size_t ii;
+    int64_t err = 0;
+    int64_t count, cum_count=0;
+    size_t last_block_size;
+    size_t leftover_bytes;
+    size_t this_iter;
+    char *last_in;
+    char *last_out;
+
+
+    ioc_chain C;
+    ioc_init(&C, in, out);
+
+
+    if (block_size == 0) {
+        block_size = bshuf_default_block_size(elem_size);
+    }
+    if (block_size % BSHUF_BLOCKED_MULT) return -81;
+
+#if defined(_OPENMP)
+    #pragma omp parallel for schedule(dynamic, 1) \
+            private(count) reduction(+ : cum_count)
+#endif
+    for (ii = 0; ii < size / block_size; ii ++) {
+        count = fun(&C, block_size, elem_size);
+        if (count < 0) err = count;
+        cum_count += count;
+    }
+
+    last_block_size = size % block_size;
+    last_block_size = last_block_size - last_block_size % BSHUF_BLOCKED_MULT;
+    if (last_block_size) {
+        count = fun(&C, last_block_size, elem_size);
+        if (count < 0) err = count;
+        cum_count += count;
+    }
+
+    if (err < 0) return err;
+
+    leftover_bytes = size % BSHUF_BLOCKED_MULT * elem_size;
+    //this_iter;
+    last_in = (char *) ioc_get_in(&C, &this_iter);
+    ioc_set_next_in(&C, &this_iter, (void *) (last_in + leftover_bytes));
+    last_out = (char *) ioc_get_out(&C, &this_iter);
+    ioc_set_next_out(&C, &this_iter, (void *) (last_out + leftover_bytes));
+
+    memcpy(last_out, last_in, leftover_bytes);
+
+    ioc_destroy(&C);
+
+    return cum_count + leftover_bytes;
+}
+
+
+/* Bitshuffle a single block. */
+int64_t bshuf_bitshuffle_block(ioc_chain *C_ptr, \
+        const size_t size, const size_t elem_size) {
+
+    size_t this_iter;
+    const void *in;
+    void *out;
+    int64_t count;
+
+
+    
+    in = ioc_get_in(C_ptr, &this_iter);
+    ioc_set_next_in(C_ptr, &this_iter,
+            (void*) ((char*) in + size * elem_size));
+    out = ioc_get_out(C_ptr, &this_iter);
+    ioc_set_next_out(C_ptr, &this_iter,
+            (void *) ((char *) out + size * elem_size));
+
+    count = bshuf_trans_bit_elem(in, out, size, elem_size);
+    return count;
+}
+
+
+/* Bitunshuffle a single block. */
+int64_t bshuf_bitunshuffle_block(ioc_chain* C_ptr, \
+        const size_t size, const size_t elem_size) {
+
+
+    size_t this_iter;
+    const void *in;
+    void *out;
+    int64_t count;
+
+
+
+
+    in = ioc_get_in(C_ptr, &this_iter);
+    ioc_set_next_in(C_ptr, &this_iter,
+            (void*) ((char*) in + size * elem_size));
+    out = ioc_get_out(C_ptr, &this_iter);
+    ioc_set_next_out(C_ptr, &this_iter,
+            (void *) ((char *) out + size * elem_size));
+
+    count = bshuf_untrans_bit_elem(in, out, size, elem_size);
+    return count;
+}
+
+
+/* Write a 64 bit unsigned integer to a buffer in big endian order. */
+void bshuf_write_uint64_BE(void* buf, uint64_t num) {
+    int ii;
+    uint8_t* b = (uint8_t*) buf;
+    uint64_t pow28 = 1 << 8;
+    for (ii = 7; ii >= 0; ii--) {
+        b[ii] = num % pow28;
+        num = num / pow28;
+    }
+}
+
+
+/* Read a 64 bit unsigned integer from a buffer big endian order. */
+uint64_t bshuf_read_uint64_BE(void* buf) {
+    int ii;
+    uint8_t* b = (uint8_t*) buf;
+    uint64_t num = 0, pow28 = 1 << 8, cp = 1;
+    for (ii = 7; ii >= 0; ii--) {
+        num += b[ii] * cp;
+        cp *= pow28;
+    }
+    return num;
+}
+
+
+/* Write a 32 bit unsigned integer to a buffer in big endian order. */
+void bshuf_write_uint32_BE(void* buf, uint32_t num) {
+    int ii;
+    uint8_t* b = (uint8_t*) buf;
+    uint32_t pow28 = 1 << 8;
+    for (ii = 3; ii >= 0; ii--) {
+        b[ii] = num % pow28;
+        num = num / pow28;
+    }
+}
+
+
+/* Read a 32 bit unsigned integer from a buffer big endian order. */
+uint32_t bshuf_read_uint32_BE(const void* buf) {
+    int ii;
+    uint8_t* b = (uint8_t*) buf;
+    uint32_t num = 0, pow28 = 1 << 8, cp = 1;
+    for (ii = 3; ii >= 0; ii--) {
+        num += b[ii] * cp;
+        cp *= pow28;
+    }
+    return num;
+}
+
+
+/* ---- Public functions ----
+ *
+ * See header file for description and usage.
+ *
+ */
+
+size_t bshuf_default_block_size(const size_t elem_size) {
+    // This function needs to be absolutely stable between versions.
+    // Otherwise encoded data will not be decodable.
+
+    size_t block_size = BSHUF_TARGET_BLOCK_SIZE_B / elem_size;
+    // Ensure it is a required multiple.
+    block_size = (block_size / BSHUF_BLOCKED_MULT) * BSHUF_BLOCKED_MULT;
+    return MAX(block_size, BSHUF_MIN_RECOMMEND_BLOCK);
+}
+
+
+int64_t bshuf_bitshuffle(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size) {
+
+    return bshuf_blocked_wrap_fun(&bshuf_bitshuffle_block, in, out, size,
+            elem_size, block_size);
+}
+
+
+int64_t bshuf_bitunshuffle(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size) {
+
+    return bshuf_blocked_wrap_fun(&bshuf_bitunshuffle_block, in, out, size,
+            elem_size, block_size);
+}
+
+
+#undef TRANS_BIT_8X8
+#undef TRANS_ELEM_TYPE
+#undef MAX
+#undef CHECK_MULT_EIGHT
+#undef CHECK_ERR_FREE
+
+#undef USESSE2
+#undef USEAVX2

--- a/bitshuffle/bitshuffle_core.h
+++ b/bitshuffle/bitshuffle_core.h
@@ -1,0 +1,155 @@
+/*
+ * Bitshuffle - Filter for improving compression of typed binary data.
+ *
+ * This file is part of Bitshuffle
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ *
+ *
+ * Header File
+ *
+ * Worker routines return an int64_t which is the number of bytes processed
+ * if positive or an error code if negative.
+ *
+ * Error codes:
+ *      -1    : Failed to allocate memory.
+ *      -11   : Missing SSE.
+ *      -12   : Missing AVX.
+ *      -80   : Input size not a multiple of 8.
+ *      -81   : block_size not multiple of 8.
+ *      -91   : Decompression error, wrong number of bytes processed.
+ *      -1YYY : Error internal to compression routine with error code -YYY.
+ */
+
+
+#ifndef BITSHUFFLE_CORE_H
+#define BITSHUFFLE_CORE_H
+
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+# include <stdint.h>
+#else
+  typedef unsigned char       uint8_t;
+  typedef unsigned short      uint16_t;
+  typedef unsigned int        uint32_t;
+  typedef   signed int        int32_t;
+  typedef unsigned long long  uint64_t;
+  typedef long long           int64_t;
+#endif
+
+#include <stdlib.h>
+
+
+// These are usually set in the setup.py.
+#ifndef BSHUF_VERSION_MAJOR
+#define BSHUF_VERSION_MAJOR 0
+#define BSHUF_VERSION_MINOR 2
+#define BSHUF_VERSION_POINT 5
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* --- bshuf_using_SSE2 ----
+ *
+ * Whether routines where compiled with the SSE2 instruction set.
+ *
+ * Returns
+ * -------
+ *  1 if using SSE2, 0 otherwise.
+ *
+ */
+int bshuf_using_SSE2(void);
+
+
+/* ---- bshuf_using_AVX2 ----
+ *
+ * Whether routines where compiled with the AVX2 instruction set.
+ *
+ * Returns
+ * -------
+ *  1 if using AVX2, 0 otherwise.
+ *
+ */
+int bshuf_using_AVX2(void);
+
+
+/* ---- bshuf_default_block_size ----
+ *
+ * The default block size as function of element size.
+ *
+ * This is the block size used by the blocked routines (any routine
+ * taking a *block_size* argument) when the block_size is not provided
+ * (zero is passed).
+ *
+ * The results of this routine are guaranteed to be stable such that
+ * shuffled/compressed data can always be decompressed.
+ *
+ * Parameters
+ * ----------
+ *  elem_size : element size of data to be shuffled/compressed.
+ *
+ */
+size_t bshuf_default_block_size(const size_t elem_size);
+
+
+/* ---- bshuf_bitshuffle ----
+ *
+ * Bitshuffle the data.
+ *
+ * Transpose the bits within elements, in blocks of *block_size*
+ * elements.
+ *
+ * Parameters
+ * ----------
+ *  in : input buffer, must be of size * elem_size bytes
+ *  out : output buffer, must be of size * elem_size bytes
+ *  size : number of elements in input
+ *  elem_size : element size of typed data
+ *  block_size : Do transpose in blocks of this many elements. Pass 0 to
+ *  select automatically (recommended).
+ *
+ * Returns
+ * -------
+ *  number of bytes processed, negative error-code if failed.
+ *
+ */
+int64_t bshuf_bitshuffle(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size);
+
+
+/* ---- bshuf_bitunshuffle ----
+ *
+ * Unshuffle bitshuffled data.
+ *
+ * Untranspose the bits within elements, in blocks of *block_size*
+ * elements.
+ *
+ * To properly unshuffle bitshuffled data, *size*, *elem_size* and *block_size*
+ * must match the parameters used to shuffle the data.
+ *
+ * Parameters
+ * ----------
+ *  in : input buffer, must be of size * elem_size bytes
+ *  out : output buffer, must be of size * elem_size bytes
+ *  size : number of elements in input
+ *  elem_size : element size of typed data
+ *  block_size : Do transpose in blocks of this many elements. Pass 0 to
+ *  select automatically (recommended).
+ *
+ * Returns
+ * -------
+ *  number of bytes processed, negative error-code if failed.
+ *
+ */
+int64_t bshuf_bitunshuffle(const void* in, void* out, const size_t size,
+        const size_t elem_size, size_t block_size);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif  // BITSHUFFLE_CORE_H

--- a/bitshuffle/bitshuffle_internals.h
+++ b/bitshuffle/bitshuffle_internals.h
@@ -1,0 +1,74 @@
+/*
+ * Bitshuffle - Filter for improving compression of typed binary data.
+ *
+ * This file is part of Bitshuffle
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ */
+
+
+#ifndef BITSHUFFLE_INTERNALS_H
+#define BITSHUFFLE_INTERNALS_H
+
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+# include <stdint.h>
+#else
+  typedef unsigned char       uint8_t;
+  typedef unsigned short      uint16_t;
+  typedef unsigned int        uint32_t;
+  typedef   signed int        int32_t;
+  typedef unsigned long long  uint64_t;
+  typedef long long           int64_t;
+#endif
+
+#include <stdlib.h>
+#include "iochain.h"
+
+
+// Constants.
+#ifndef BSHUF_MIN_RECOMMEND_BLOCK
+#define BSHUF_MIN_RECOMMEND_BLOCK 128
+#define BSHUF_BLOCKED_MULT 8    // Block sizes must be multiple of this.
+#define BSHUF_TARGET_BLOCK_SIZE_B 8192
+#endif
+
+
+// Macros.
+#define CHECK_ERR_FREE(count, buf) if (count < 0) { free(buf); return count; }
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- Utility functions for internal use only ---- */
+
+int64_t bshuf_trans_bit_elem(const void* in, void* out, const size_t size,
+        const size_t elem_size);
+
+/* Read a 32 bit unsigned integer from a buffer big endian order. */
+uint32_t bshuf_read_uint32_BE(const void* buf);
+
+/* Write a 32 bit unsigned integer to a buffer in big endian order. */
+void bshuf_write_uint32_BE(void* buf, uint32_t num);
+
+int64_t bshuf_untrans_bit_elem(const void* in, void* out, const size_t size,
+        const size_t elem_size);
+
+/* Function definition for worker functions that process a single block. */
+typedef int64_t (*bshufBlockFunDef)(ioc_chain* C_ptr,
+        const size_t size, const size_t elem_size);
+
+/* Wrap a function for processing a single block to process an entire buffer in
+ * parallel. */
+int64_t bshuf_blocked_wrap_fun(bshufBlockFunDef fun, const void* in, void* out,
+        const size_t size, const size_t elem_size, size_t block_size);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif  // BITSHUFFLE_INTERNALS_H

--- a/bitshuffle/iochain.c
+++ b/bitshuffle/iochain.c
@@ -1,0 +1,90 @@
+/*
+ * IOchain - Distribute a chain of dependant IO events amoung threads.
+ *
+ * This file is part of Bitshuffle
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ *
+ */
+
+#include <stdlib.h>
+#include "iochain.h"
+
+
+void ioc_init(ioc_chain *C, const void *in_ptr_0, void *out_ptr_0) {
+#ifdef _OPENMP
+    omp_init_lock(&C->next_lock);
+    for (size_t ii = 0; ii < IOC_SIZE; ii ++) {
+        omp_init_lock(&(C->in_pl[ii].lock));
+        omp_init_lock(&(C->out_pl[ii].lock));
+    }
+#endif
+    C->next = 0;
+    C->in_pl[0].ptr = in_ptr_0;
+    C->out_pl[0].ptr = out_ptr_0;
+}
+
+
+void ioc_destroy(ioc_chain *C) {
+#ifdef _OPENMP
+    omp_destroy_lock(&C->next_lock);
+    for (size_t ii = 0; ii < IOC_SIZE; ii ++) {
+        omp_destroy_lock(&(C->in_pl[ii].lock));
+        omp_destroy_lock(&(C->out_pl[ii].lock));
+    }
+#endif
+}
+
+
+const void * ioc_get_in(ioc_chain *C, size_t *this_iter) {
+#ifdef _OPENMP
+    omp_set_lock(&C->next_lock);
+    #pragma omp flush
+#endif
+    *this_iter = C->next;
+    C->next ++;
+#ifdef _OPENMP
+    omp_set_lock(&(C->in_pl[*this_iter % IOC_SIZE].lock));
+    omp_set_lock(&(C->in_pl[(*this_iter + 1) % IOC_SIZE].lock));
+    omp_set_lock(&(C->out_pl[(*this_iter + 1) % IOC_SIZE].lock));
+    omp_unset_lock(&C->next_lock);
+#endif
+    return C->in_pl[*this_iter % IOC_SIZE].ptr;
+}
+
+
+void ioc_set_next_in(ioc_chain *C, size_t* this_iter, void* in_ptr) {
+    C->in_pl[(*this_iter + 1) % IOC_SIZE].ptr = in_ptr;
+#ifdef _OPENMP
+    omp_unset_lock(&(C->in_pl[(*this_iter + 1) % IOC_SIZE].lock));
+#endif
+}
+
+
+void * ioc_get_out(ioc_chain *C, size_t *this_iter) {
+#ifdef _OPENMP
+    omp_set_lock(&(C->out_pl[(*this_iter) % IOC_SIZE].lock));
+    #pragma omp flush
+#endif
+    void *out_ptr = C->out_pl[*this_iter % IOC_SIZE].ptr;
+#ifdef _OPENMP
+    omp_unset_lock(&(C->out_pl[(*this_iter) % IOC_SIZE].lock));
+#endif
+    return out_ptr;
+}
+
+
+void ioc_set_next_out(ioc_chain *C, size_t *this_iter, void* out_ptr) {
+    C->out_pl[(*this_iter + 1) % IOC_SIZE].ptr = out_ptr;
+#ifdef _OPENMP
+    omp_unset_lock(&(C->out_pl[(*this_iter + 1) % IOC_SIZE].lock));
+    // *in_pl[this_iter]* lock released at the end of the iteration to avoid being
+    // overtaken by previous threads and having *out_pl[this_iter]* corrupted.
+    // Especially worried about thread 0, iteration 0.
+    omp_unset_lock(&(C->in_pl[(*this_iter) % IOC_SIZE].lock));
+#endif
+}
+

--- a/bitshuffle/iochain.h
+++ b/bitshuffle/iochain.h
@@ -1,0 +1,94 @@
+/*
+ * IOchain - Distribute a chain of dependant IO events amoung threads.
+ *
+ * This file is part of Bitshuffle
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Website: http://www.github.com/kiyo-masui/bitshuffle
+ * Created: 2014
+ *
+ * See LICENSE file for details about copyright and rights to use.
+ *
+ *
+ * Header File
+ *
+ * Similar in concept to a queue. Each task includes reading an input
+ * and writing output, but the location of the input/output (the pointers)
+ * depend on the previous item in the chain.
+ *
+ * This is designed for parallelizing blocked compression/decompression IO,
+ * where the destination of a compressed block depends on the compressed size
+ * of all previous blocks.
+ *
+ * Implemented with OpenMP locks.
+ *
+ *
+ * Usage
+ * -----
+ *  - Call `ioc_init` in serial block.
+ *  - Each thread should create a local variable *size_t this_iter* and 
+ *    pass its address to all function calls. Its value will be set
+ *    inside the functions and is used to identify the thread.
+ *  - Each thread must call each of the `ioc_get*` and `ioc_set*` methods
+ *    exactly once per iteration, starting with `ioc_get_in` and ending
+ *    with `ioc_set_next_out`.
+ *  - The order (`ioc_get_in`, `ioc_set_next_in`, *work*, `ioc_get_out`,
+ *    `ioc_set_next_out`, *work*) is most efficient.
+ *  - Have each thread call `ioc_end_pop`.
+ *  - `ioc_get_in` is blocked until the previous entry's
+ *    `ioc_set_next_in` is called.
+ *  - `ioc_get_out` is blocked until the previous entry's
+ *    `ioc_set_next_out` is called.
+ *  - There are no blocks on the very first iteration.
+ *  - Call `ioc_destroy` in serial block.
+ *  - Safe for num_threads >= IOC_SIZE (but less efficient).
+ *
+ */
+
+
+#ifndef IOCHAIN_H
+#define IOCHAIN_H
+
+
+#include <stdlib.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+
+#define IOC_SIZE 33
+
+
+typedef struct ioc_ptr_and_lock {
+#ifdef _OPENMP
+    omp_lock_t lock;
+#endif
+    void *ptr;
+} ptr_and_lock;
+
+typedef struct ioc_const_ptr_and_lock {
+#ifdef _OPENMP
+    omp_lock_t lock;
+#endif
+    const void *ptr;
+} const_ptr_and_lock;
+
+
+typedef struct ioc_chain {
+#ifdef _OPENMP
+    omp_lock_t next_lock;
+#endif
+    size_t next;
+    const_ptr_and_lock in_pl[IOC_SIZE];
+    ptr_and_lock out_pl[IOC_SIZE];
+} ioc_chain;
+
+
+void ioc_init(ioc_chain *C, const void *in_ptr_0, void *out_ptr_0);
+void ioc_destroy(ioc_chain *C);
+const void * ioc_get_in(ioc_chain *C, size_t *this_iter);
+void ioc_set_next_in(ioc_chain *C, size_t* this_iter, void* in_ptr);
+void * ioc_get_out(ioc_chain *C, size_t *this_iter);
+void ioc_set_next_out(ioc_chain *C, size_t *this_iter, void* out_ptr);
+
+#endif  // IOCHAIN_H
+

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -338,6 +338,8 @@ public:
 
     std::vector<std::unordered_map<std::string, uint64_t> > get_statistics();
 
+    std::vector< std::vector< std::shared_ptr<assembled_chunk> > > get_ringbuf_snapshots(std::vector<uint64_t> beams);
+
     ~intensity_network_stream();
 
 protected:

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -475,6 +475,8 @@ struct assembled_chunk : noncopyable {
     float *offsets = nullptr;  // shape (constants::nfreq_coarse, nt_coarse)
     uint8_t *data = nullptr;   // shape (constants::nfreq_coarse, nupfreq, constants::nt_per_assembled_chunk)
 
+    bool msgpack_bitshuffle = false;
+
     assembled_chunk(int beam_id, int nupfreq, int nt_per_packet, int fpga_counts_per_sample, uint64_t ichunk);
     virtual ~assembled_chunk();
     
@@ -486,6 +488,8 @@ struct assembled_chunk : noncopyable {
     // Static factory function which returns either the assembled_chunk base class, or the fast_assembled_chunk
     // subclass (see below), based on the packet parameters.
     static std::shared_ptr<assembled_chunk> make(int beam_id, int nupfreq, int nt_per_packet, int fpga_counts_per_sample, uint64_t ichunk);
+
+    static std::shared_ptr<assembled_chunk> read_msgpack_file(const std::string& filename);
 
     // Utility functions currently used only for testing.
     void fill_with_copy(const std::shared_ptr<assembled_chunk> &x);

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -419,6 +419,7 @@ protected:
     intensity_network_stream(const initializer &x);
 
     void _open_socket();
+    void _network_flush_packets();
     void _add_event_counts(std::vector<int64_t> &event_subcounts);
 
     static void *network_pthread_main(void *);

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -493,7 +493,14 @@ struct assembled_chunk : noncopyable {
 
     // HDF5 file output
     void write_hdf5_file(const std::string &filename);
+
+    // msgpack file output
+    void write_msgpack_file(const std::string &filename);
+
 };
+
+
+//#include <assembled_chunk_msgpack.hpp>
 
 
 // For some choices of packet parameters (the precise criterion is nt_per_packet == 16 and

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -552,7 +552,7 @@ public:
 	int fpga_counts_per_sample = 0;
 	float wt_cutoff = constants::default_wt_cutoff;
 	double target_gbps = constants::default_gbps;   // if 0.0, then data will be written as quickly as possible!
-    int bind_port = 0; // 0: don't bind; send from randomly assigned port
+        int bind_port = 0; // 0: don't bind; send from randomly assigned port
 
 	bool is_blocking = true;
 	bool emit_warning_on_buffer_drop = true;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -484,6 +484,9 @@ struct assembled_chunk : noncopyable {
     // Utility functions currently used only for testing.
     void fill_with_copy(const std::shared_ptr<assembled_chunk> &x);
     void randomize(std::mt19937 &rng);
+
+    // HDF5 file output
+    void write_hdf5_file(const std::string &filename);
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -551,6 +551,7 @@ public:
 	int fpga_counts_per_sample = 0;
 	float wt_cutoff = constants::default_wt_cutoff;
 	double target_gbps = constants::default_gbps;   // if 0.0, then data will be written as quickly as possible!
+    int bind_port = 0; // 0: don't bind; send from randomly assigned port
 
 	bool is_blocking = true;
 	bool emit_warning_on_buffer_drop = true;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -589,7 +589,6 @@ public:
     const uint64_t fpga_counts_per_chunk;
     const double target_gbps;
 
-    
     // It's convenient to initialize intensity_network_ostreams using a static factory function make(),
     // rather than having a public constructor.  Note that make() spawns a network thread which runs
     // in the background.
@@ -653,6 +652,9 @@ protected:
     static void *network_pthread_main(void *opaque_args);
 
     void _network_thread_body();
+
+    // For testing purposes (eg, can create a subclass that randomly drops packets), a wrapper on the underlying packet send() function.
+    virtual ssize_t _send(int socket, const uint8_t* packet, int nbytes, int flags);
 
     void _open_socket();
     void _announce_end_of_stream();

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -589,6 +589,10 @@ public:
     //   intensity + ((b + fcoarse*nupfreq) * nupfreq + u) * stride + t
 
     void send_chunk(const float *intensity, const float *weights, int stride, uint64_t fpga_count);
+
+    void get_statistics(int64_t& curr_timestamp,
+                        int64_t& npackets_sent,
+                        int64_t& nbytes_sent);
     
     // Called when there is no more data; sends end-of-stream packets.
     void end_stream(bool join_network_thread);
@@ -606,8 +610,7 @@ protected:
     std::string hostname;
     uint16_t udp_port = constants::default_udp_port;
     
-    // Currently, this data is not protected by a lock, since it's only accessed by the network thread.
-    // If we want to make this data accessible by other threads, this needs to be changed.
+    pthread_mutex_t statistics_lock;
     int64_t curr_timestamp = 0;    // microseconds between first packet and most recent packet
     int64_t npackets_sent = 0;
     int64_t nbytes_sent = 0;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -337,6 +337,7 @@ public:
     std::vector<int64_t> get_event_counts();
 
     std::unordered_map<std::string, uint64_t> get_perhost_packets();
+    std::unordered_map<uint64_t, uint64_t> get_perhost_packets_raw();
 
     std::vector<std::unordered_map<std::string, uint64_t> > get_statistics();
 
@@ -384,7 +385,7 @@ protected:
     int sockfd = -1;
     std::unique_ptr<udp_packet_list> incoming_packet_list;
     std::vector<int64_t> network_thread_event_subcounts;
-    std::unordered_map<std::string, uint64_t> network_thread_perhost_packets;
+    std::unordered_map<uint64_t, uint64_t> network_thread_perhost_packets;
     char _pad2[constants::cache_line_size];
 
     // Used only by the assembler thread
@@ -412,7 +413,7 @@ protected:
 
     pthread_mutex_t event_lock;
     std::vector<int64_t> cumulative_event_counts;
-    std::unordered_map<std::string, uint64_t> perhost_packets;
+    std::unordered_map<uint64_t, uint64_t> perhost_packets;
 
     // The actual constructor is protected, so it can be a helper function 
     // for intensity_network_stream::make(), but can't be called otherwise.

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include <memory>
 #include <random>
 #include <hdf5.h>
@@ -334,6 +335,8 @@ public:
 
     initializer get_initializer();
     std::vector<int64_t> get_event_counts();
+
+    std::vector<std::unordered_map<std::string, uint64_t> > get_statistics();
 
     ~intensity_network_stream();
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -336,6 +336,8 @@ public:
     initializer get_initializer();
     std::vector<int64_t> get_event_counts();
 
+    std::unordered_map<std::string, uint64_t> get_perhost_packets();
+
     std::vector<std::unordered_map<std::string, uint64_t> > get_statistics();
 
     std::vector< std::vector< std::shared_ptr<assembled_chunk> > > get_ringbuf_snapshots(std::vector<uint64_t> beams);
@@ -382,6 +384,7 @@ protected:
     int sockfd = -1;
     std::unique_ptr<udp_packet_list> incoming_packet_list;
     std::vector<int64_t> network_thread_event_subcounts;
+    std::unordered_map<std::string, uint64_t> network_thread_perhost_packets;
     char _pad2[constants::cache_line_size];
 
     // Used only by the assembler thread
@@ -409,6 +412,7 @@ protected:
 
     pthread_mutex_t event_lock;
     std::vector<int64_t> cumulative_event_counts;
+    std::unordered_map<std::string, uint64_t> perhost_packets;
 
     // The actual constructor is protected, so it can be a helper function 
     // for intensity_network_stream::make(), but can't be called otherwise.

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -291,8 +291,8 @@ protected:
     pthread_cond_t cond_assembled_chunks_added;
 
     std::shared_ptr<assembled_chunk> assembled_ringbuf[constants::assembled_ringbuf_capacity];
-    int assembled_ringbuf_pos = 0;
-    int assembled_ringbuf_size = 0;
+    uint64_t assembled_ringbuf_pos  = 0;
+    uint64_t assembled_ringbuf_size = 0;
     bool doneflag = false;
 };
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -256,6 +256,9 @@ public:
     // to indicate end-of-stream.
     std::shared_ptr<assembled_chunk> get_assembled_chunk();
 
+    int get_assembled_ringbuf_size();
+
+    std::vector<std::shared_ptr<assembled_chunk> > get_ringbuf_snapshot();
 
 protected:
     const intensity_network_stream::initializer ini_params;

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -256,8 +256,6 @@ public:
     // to indicate end-of-stream.
     std::shared_ptr<assembled_chunk> get_assembled_chunk();
 
-    int get_assembled_ringbuf_size();
-
     std::vector<std::shared_ptr<assembled_chunk> > get_ringbuf_snapshot();
 
 protected:

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -432,6 +432,7 @@ template<typename T> inline hid_t hdf5_type();
 
 // Reference: https://www.hdfgroup.org/HDF5/doc/H5.user/Datatypes.html
 template<> inline hid_t hdf5_type<int>()            { return H5T_NATIVE_INT; }
+template<> inline hid_t hdf5_type<unsigned long long>() { return H5T_NATIVE_ULLONG; }
 template<> inline hid_t hdf5_type<float>()          { return H5T_NATIVE_FLOAT; }
 template<> inline hid_t hdf5_type<double>()         { return H5T_NATIVE_DOUBLE; }
 template<> inline hid_t hdf5_type<unsigned char>()  { return H5T_NATIVE_UCHAR; }

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -258,6 +258,16 @@ public:
 
     std::vector<std::shared_ptr<assembled_chunk> > get_ringbuf_snapshot();
 
+    // Returns stats about the ring buffer.
+    //  *ringbuf_pos* is the next "chunk" that will be delivered to get_assembled_chunk().
+    //  *ringbuf_size* is the number of chunks available to be consumed by get_assembled_chunk().
+    //  *ringbuf_nelements* counts the number of valid chunks, including old chunks that have already been consumed by get_assembled_chunk.
+    //  *ringbuf_capacity* is the maximum number of chunks that can be held in the ring buffer.
+    void get_ringbuf_size(uint64_t& ringbuf_pos,
+                          uint64_t& ringbuf_size,
+                          uint64_t& ringbuf_nelements,
+                          uint64_t& ringbuf_capacity);
+
 protected:
     const intensity_network_stream::initializer ini_params;
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -259,14 +259,16 @@ public:
     std::vector<std::shared_ptr<assembled_chunk> > get_ringbuf_snapshot();
 
     // Returns stats about the ring buffer.
-    //  *ringbuf_pos* is the next "chunk" that will be delivered to get_assembled_chunk().
+    //  *ringbuf_chunk* is the next chunk number that will be delivered to get_assembled_chunk().  (= assembled_ringbuf_pos)
     //  *ringbuf_size* is the number of chunks available to be consumed by get_assembled_chunk().
-    //  *ringbuf_nelements* counts the number of valid chunks, including old chunks that have already been consumed by get_assembled_chunk.
     //  *ringbuf_capacity* is the maximum number of chunks that can be held in the ring buffer.
-    void get_ringbuf_size(uint64_t& ringbuf_pos,
-                          uint64_t& ringbuf_size,
-                          uint64_t& ringbuf_nelements,
-                          uint64_t& ringbuf_capacity);
+    //  *ringbuf_nelements* counts the number of valid chunks, including old chunks that have already been consumed by get_assembled_chunk.
+    //  *ringbuf_oldest_chunk* is the smallest chunk number available in the ring buffer (including ones that have already been consumed by get_assembled_chunk().)
+    void get_ringbuf_size(uint64_t* ringbuf_chunk,
+                          uint64_t* ringbuf_size,
+                          uint64_t* ringbuf_capacity,
+                          uint64_t* ringbuf_nelements,
+                          uint64_t* ringbuf_oldest_chunk);
 
 protected:
     const intensity_network_stream::initializer ini_params;

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -356,7 +356,7 @@ void intensity_network_ostream::_network_thread_body()
     for (;;) {
 	if (!ringbuf->get_packet_list(packet_list))
 	    break;   // end of stream reached (probably normal termination)
-	
+
 	// Loop over packets
 	for (int ipacket = 0; ipacket < packet_list->curr_npackets; ipacket++) {
 	    const uint8_t *packet = packet_list->get_packet_data(ipacket);
@@ -396,7 +396,7 @@ void intensity_network_ostream::_network_thread_body()
             pthread_mutex_unlock(&statistics_lock);
 	}
     }
-    
+
     this->_announce_end_of_stream();
 }
 

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -142,6 +142,7 @@ intensity_network_ostream::intensity_network_ostream(const initializer &ini_para
 	coarse_freq_ids_16bit[i] = uint16_t(ini_params.coarse_freq_ids[i]);
     
     pthread_mutex_init(&this->state_lock, NULL);
+    pthread_mutex_init(&this->statistics_lock, NULL);
     pthread_cond_init(&this->cond_state_changed, NULL);
 
     int capacity = constants::output_ringbuf_capacity;
@@ -159,6 +160,7 @@ intensity_network_ostream::~intensity_network_ostream()
 
     pthread_cond_destroy(&cond_state_changed);
     pthread_mutex_destroy(&state_lock);
+    pthread_mutex_destroy(&statistics_lock);
 }
 
 

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -374,9 +374,9 @@ void intensity_network_ostream::_network_thread_body()
 		int64_t target_timestamp = last_timestamp + int64_t(8.0e-3 * last_packet_nbytes / target_gbps);		
 		if (tstamp < target_timestamp) {
 		    xusleep(target_timestamp - tstamp);
-            pthread_mutex_lock(&statistics_lock);
+                    pthread_mutex_lock(&statistics_lock);
 		    curr_timestamp = target_timestamp;
-            pthread_mutex_unlock(&statistics_lock);
+                    pthread_mutex_unlock(&statistics_lock);
 		}
 	    }
 

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -147,7 +147,6 @@ intensity_network_ostream::intensity_network_ostream(const initializer &ini_para
     int capacity = constants::output_ringbuf_capacity;
     this->ringbuf = make_unique<udp_packet_ringbuf> (capacity, npackets_per_chunk, nbytes_per_chunk);
     this->tmp_packet_list = make_unique<udp_packet_list> (npackets_per_chunk, nbytes_per_chunk);
-    cout << "Created tmp_packet_list to hold " << npackets_per_chunk << " packets" << endl;
 }
 
 
@@ -219,8 +218,6 @@ void intensity_network_ostream::_encode_chunk(const float *intensity, const floa
     int beam_stride = nfreq_coarse_per_chunk * nupfreq * stride;
     int nf_outer = nfreq_coarse_per_chunk / nfreq_coarse_per_packet;
     int nt_outer = nt_per_chunk / nt_per_packet;
-
-    cout << "encode_chunk: nf_outer " << nf_outer << ", nt_outer " << nt_outer << " -> n packets " << nf_outer * nt_outer << endl;
 
     if (fpga_count % (fpga_counts_per_sample * nt_per_packet) != 0)
 	throw runtime_error("intensity_network_ostream::_encode_chunk(): fpga count must be divisible by (fpga_counts_per_sample * nt_per_packet)");
@@ -343,22 +340,16 @@ void intensity_network_ostream::_network_thread_body()
 
     // to be initialized when first packet is sent
     struct timeval tv_ini;
-
-    cout << "Network thread body starting" << endl;
     
     // Loop over packet_lists
     for (;;) {
 	if (!ringbuf->get_packet_list(packet_list))
 	    break;   // end of stream reached (probably normal termination)
-
-    //cout << "Sending " << packet_list->curr_npackets << " packets" << endl;
 	
 	// Loop over packets
 	for (int ipacket = 0; ipacket < packet_list->curr_npackets; ipacket++) {
 	    const uint8_t *packet = packet_list->get_packet_data(ipacket);
 	    const int packet_nbytes = packet_list->get_packet_nbytes(ipacket);
-
-        
 
         pthread_mutex_lock(&statistics_lock);
 	    if (npackets_sent == 0)
@@ -380,11 +371,6 @@ void intensity_network_ostream::_network_thread_body()
 		}
 	    }
 
-        /*{
-            intensity_packet* inpacket = (intensity_packet*)packet;
-            cout << "Sending packet " << ipacket << "/" << packet_list->curr_npackets << ": fpga_counts " << inpacket->fpga_count << endl;
-         }*/
-
 	    ssize_t n = send(this->sockfd, packet, packet_nbytes, 0);
 
 	    if (n < 0)
@@ -399,8 +385,6 @@ void intensity_network_ostream::_network_thread_body()
         pthread_mutex_unlock(&statistics_lock);
 	}
     }
-
-    cout << "Network thread body quitting" << endl;
     
     this->_announce_end_of_stream();
 }

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -204,7 +204,16 @@ void intensity_network_ostream::_open_socket()
     if (err < 0)
 	throw runtime_error(string("ch_frb_io: setsockopt(SO_SNDBUF) failed: ") + strerror(errno));
     
-    // Note: bind() not called, so source port number of outgoing packets will be arbitrarily assigned
+    if (ini_params.bind_port) {
+        struct sockaddr_in server_address;
+        memset(&server_address, 0, sizeof(server_address));
+        server_address.sin_family = AF_INET;
+        inet_pton(AF_INET, "0.0.0.0", &server_address.sin_addr);
+        server_address.sin_port = htons(ini_params.bind_port);
+        int err = ::bind(sockfd, (struct sockaddr *) &server_address, sizeof(server_address));
+        if (err < 0)
+            throw runtime_error(string("ch_frb_io: bind() failed: ") + strerror(errno));
+    }
 
     if (connect(sockfd, reinterpret_cast<struct sockaddr *> (&saddr), sizeof(saddr)) < 0)
 	throw runtime_error("ch_frb_io: couldn't connect udp socket to dstname '" + ini_params.dstname + "': " + strerror(errno));

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -3,6 +3,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 
+#include <random>
 #include <iostream>
 #include "ch_frb_io_internals.hpp"
 
@@ -382,8 +383,7 @@ void intensity_network_ostream::_network_thread_body()
 		}
 	    }
 
-	    ssize_t n = send(this->sockfd, packet, packet_nbytes, 0);
-
+            ssize_t n = this->_send(this->sockfd, packet, packet_nbytes, 0);
 	    if (n < 0)
 		throw runtime_error(string("chime intensity_network_ostream: udp packet send() failed: ") + strerror(errno));
 	    if (n != packet_nbytes)
@@ -398,6 +398,10 @@ void intensity_network_ostream::_network_thread_body()
     }
 
     this->_announce_end_of_stream();
+}
+
+ssize_t intensity_network_ostream::_send(int socket, const uint8_t* packet, int nbytes, int flags) {
+    return send(socket, packet, nbytes, flags);
 }
 
 void intensity_network_ostream::get_statistics(int64_t& curr_timestamp,

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -360,14 +360,14 @@ void intensity_network_ostream::_network_thread_body()
 	    const uint8_t *packet = packet_list->get_packet_data(ipacket);
 	    const int packet_nbytes = packet_list->get_packet_nbytes(ipacket);
 
-        pthread_mutex_lock(&statistics_lock);
+            pthread_mutex_lock(&statistics_lock);
 	    if (npackets_sent == 0)
 		tv_ini = xgettimeofday();
 
 	    int64_t last_timestamp = this->curr_timestamp;
-        int64_t tstamp = this->curr_timestamp = usec_between(tv_ini, xgettimeofday());
-        int64_t npackets = this->npackets_sent;
-        pthread_mutex_unlock(&statistics_lock);
+            int64_t tstamp = this->curr_timestamp = usec_between(tv_ini, xgettimeofday());
+            int64_t npackets = this->npackets_sent;
+            pthread_mutex_unlock(&statistics_lock);
 
 	    // Throttling logic: compare actual bandwidth to 'target_gbps' and sleep if necessary.
 	    if ((target_gbps > 0.0) && (npackets > 0)) {
@@ -388,10 +388,10 @@ void intensity_network_ostream::_network_thread_body()
 		throw runtime_error(string("chime intensity_network_ostream: udp packet send() sent ") + to_string(n) + "/" + to_string(packet_nbytes) + " bytes?!");
 
 	    last_packet_nbytes = packet_nbytes;
-        pthread_mutex_lock(&statistics_lock);
+            pthread_mutex_lock(&statistics_lock);
 	    this->nbytes_sent += packet_nbytes;
 	    this->npackets_sent++;
-        pthread_mutex_unlock(&statistics_lock);
+            pthread_mutex_unlock(&statistics_lock);
 	}
     }
     

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -1,7 +1,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-#include <netinet/in.h>
 #include <iostream>
 #include "ch_frb_io_internals.hpp"
 

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -568,7 +568,7 @@ void intensity_network_stream::_network_flush_packets() {
     pthread_mutex_lock(&this->event_lock);
     for (auto it = network_thread_perhost_packets.begin();
          it != network_thread_perhost_packets.end(); it++) {
-        perhost_packets[it->first] += it->second;
+        perhost_packets[it->first] = it->second;
     }
     pthread_mutex_unlock(&this->event_lock);
 }

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -428,6 +428,8 @@ void intensity_network_stream::_network_thread_body()
 	pthread_cond_wait(&this->cond_state_changed, &this->state_lock);
     }
 
+    cout << "Network thread: stream started." << endl;
+
     // Start listening on socket 
 
     struct sockaddr_in server_address;
@@ -475,14 +477,17 @@ void intensity_network_stream::_network_thread_body()
 
 	// Periodically flush packets to assembler thread (only happens if packet rate is low; normal case is that the packet_list fills first)
 	if (curr_timestamp > incoming_packet_list_timestamp + constants::unassembled_ringbuf_timeout_usec) {
+        cout << "Network thread flushing to assembler thread" << endl;
 	    this->_put_unassembled_packets();
 	    this->_add_event_counts(network_thread_event_subcounts);
 	    incoming_packet_list_timestamp = curr_timestamp;
 	}
 
 	// Read new packet from socket (note that socket has a timeout, so this call can time out)
+    //cout << "Network thread reading from socket..." << endl;
 	uint8_t *packet_data = incoming_packet_list->data_end;
 	int packet_nbytes = read(sockfd, packet_data, constants::max_input_udp_packet_size + 1);
+    //cout << "Read " << packet_nbytes << "-byte packet from socket" << endl;
 
 	// Check for error or timeout in read()
 	if (packet_nbytes < 0) {
@@ -490,6 +495,11 @@ void intensity_network_stream::_network_thread_body()
 		continue;  // normal timeout
 	    throw runtime_error(string("ch_frb_io network thread: read() failed: ") + strerror(errno));
 	}
+
+    {
+        intensity_packet* inpacket = (intensity_packet*)packet_data;
+        cout << "Received packet with fpga_counts " << inpacket->fpga_count << endl;
+    }
 
 	event_subcounts[event_type::byte_received] += packet_nbytes;
 	event_subcounts[event_type::packet_received]++;
@@ -505,6 +515,8 @@ void intensity_network_stream::_network_thread_body()
 	// Special logic for processing first packet, which triggers some initializations.
 	if (is_first_packet) {
 	    intensity_packet packet;
+
+        cout << "First packet" << endl;
 
 	    if (!packet.decode(packet_data, packet_nbytes)) {
 		event_subcounts[event_type::packet_bad]++;
@@ -531,7 +543,10 @@ void intensity_network_stream::_network_thread_body()
 
 	incoming_packet_list->add_packet(packet_nbytes);
 
+    cout << "Adding packet to incoming list: now " << incoming_packet_list->curr_npackets << "/" << incoming_packet_list->max_npackets << " packets" << endl;
+
 	if (incoming_packet_list->is_full) {
+        cout << "Flushing packets to assembler because packet list full" << endl;
 	    this->_put_unassembled_packets();
 	    this->_add_event_counts(network_thread_event_subcounts);
 	}
@@ -622,9 +637,11 @@ void intensity_network_stream::_assembler_thread_body()
 
     // ... and wait for first_packet_received flag to be set
     for (;;) {
+        cout << "Assembler thread waiting for first packet..." << endl;
    	if (this->stream_end_requested) {
 	    // This case can arise if end_stream() is called early
 	    pthread_mutex_unlock(&this->state_lock);
+        cout << "Stream end requested!" << endl;
 	    return;
 	}
 	if (this->first_packet_received) {
@@ -642,6 +659,8 @@ void intensity_network_stream::_assembler_thread_body()
     // in the network thread, since we could coalesce the 'first_packet_received' and 'assemblers_initialized'
     // states into a single state, but this led to transient packet loss which was problematic for unit tests.)
 
+    cout << "Assembler: Received first packet!" << endl;
+
     this->assemblers.resize(nassemblers);
     for (int ix = 0; ix < nassemblers; ix++)
 	assemblers[ix] = make_unique<assembled_chunk_ringbuf>(ini_params, ini_params.beam_ids[ix], nupfreq, nt_per_packet, fpga_counts_per_sample, this->fp_fpga_count);
@@ -650,6 +669,8 @@ void intensity_network_stream::_assembler_thread_body()
     this->assemblers_initialized = true;
     pthread_cond_broadcast(&this->cond_state_changed);
     pthread_mutex_unlock(&this->state_lock);
+
+    cout << "Assemblers initialized!" << endl;
     
     auto packet_list = make_unique<udp_packet_list> (constants::max_unassembled_packets_per_list, constants::max_unassembled_nbytes_per_list);
     int64_t *event_subcounts = &this->assembler_thread_event_subcounts[0];
@@ -657,10 +678,29 @@ void intensity_network_stream::_assembler_thread_body()
     // Main packet loop
 
     while (unassembled_ringbuf->get_packet_list(packet_list)) {
+
+        {
+            cout << "Assembling packet list: " << packet_list->curr_npackets <<
+                " with fpga_counts: { ";
+            uint64_t last_fpga_count = 999999999;
+            for (int ipacket = 0; ipacket < packet_list->curr_npackets; ipacket++) {
+                uint8_t *packet_data = packet_list->get_packet_data(ipacket);
+                intensity_packet* inpacket = (intensity_packet*)packet_data;
+                if (inpacket->fpga_count != last_fpga_count) {
+                    cout << inpacket->fpga_count << "  ";
+                    last_fpga_count = inpacket->fpga_count;
+                }
+            }
+            cout << "}" << endl;
+        }
+            
+
 	for (int ipacket = 0; ipacket < packet_list->curr_npackets; ipacket++) {
             uint8_t *packet_data = packet_list->get_packet_data(ipacket);
             int packet_nbytes = packet_list->get_packet_nbytes(ipacket);
 	    intensity_packet packet;
+
+        //cout << "Packet (" << packet_nbytes << " bytes) for beams " << this->ini_params.beam_ids[0] << "+" << endl;
 
 	    if (!packet.decode(packet_data, packet_nbytes)) {
 		event_subcounts[event_type::packet_bad]++;
@@ -700,6 +740,12 @@ void intensity_network_stream::_assembler_thread_body()
 	    // Danger zone: we modify the packet by leaving its pointers in place, but shortening its
 	    // length fields.  The new packet corresponds to a subset of the original packet containing
 	    // only beam index zero.  This scheme avoids the overhead of copying the packet.
+
+        cout << "Packet " << ipacket << "/" << packet_list->curr_npackets
+             << ": fpga_count " << packet.fpga_count
+             << ", nbeams " << packet.nbeams
+             << ", nfcoarse " << packet.nfreq_coarse
+             << ", ntsamp " << packet.ntsamp << endl;
 	    
 	    packet.data_nbytes = new_data_nbytes;
 	    packet.nbeams = 1;
@@ -727,6 +773,7 @@ void intensity_network_stream::_assembler_thread_body()
 		    }
 
 		    // Match found
+            //cout << "Packet for beam " << packet_id << endl;
 		    assemblers[assembler_ix]->put_unassembled_packet(packet, event_subcounts);
 		    break;
 		}

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -265,13 +265,11 @@ intensity_network_stream::get_statistics() {
     assemblers_init = this->assemblers_initialized;
     pthread_mutex_unlock(&this->state_lock);
 
-    m["first_packet_received"] = first_packet;
-
+    m["first_packet_received"]  =  first_packet;
     m["nupfreq"]                = (first_packet ? this->fp_nupfreq : 0);
     m["nt_per_packet"]          = (first_packet ? this->fp_nt_per_packet : 0);
-    m["fpga_counts_per_sample"] = (first_packet ? this->fp_fpga_counts_per_sample
-                                   : 0);
-    m["fpga_count"]            = (first_packet ? this->fp_fpga_count : 0);
+    m["fpga_counts_per_sample"] = (first_packet ? this->fp_fpga_counts_per_sample : 0);
+    m["fpga_count"]             = (first_packet ? this->fp_fpga_count : 0);
 
     std::vector<int64_t> counts = get_event_counts();
     m["count_bytes_received"     ] = counts[event_type::byte_received];
@@ -286,14 +284,14 @@ intensity_network_stream::get_statistics() {
     m["count_assembler_misses"   ] = counts[event_type::assembler_miss];
     m["count_assembler_drops"    ] = counts[event_type::assembled_chunk_dropped];
     m["count_assembler_queued"   ] = counts[event_type::assembled_chunk_queued];
-    //int nbeams = this->assemblers.size();
+
     int nbeams = this->ini_params.beam_ids.size();
     m["nbeams"] = nbeams;
     R.push_back(m);
 
     for (int b=0; b<nbeams; b++) {
-        cout << "get_statistics()... beam " << b << " of " << nbeams << endl;
-        cout << "assemblers_init: " << assemblers_init << endl;
+        //cout << "get_statistics()... beam " << b << " of " << nbeams << endl;
+        //cout << "assemblers_init: " << assemblers_init << endl;
         m.clear();
         m["beam_id"] = this->ini_params.beam_ids[b];
         if (assemblers_init) {
@@ -302,7 +300,7 @@ intensity_network_stream::get_statistics() {
             std::vector<std::shared_ptr<assembled_chunk> > snap = this->assemblers[b]->get_ringbuf_snapshot();
             m["ringbuf_size"] = snap.size();
 
-            cout << "Ring buffer length: " << snap.size() << endl;
+            //cout << "Ring buffer length: " << snap.size() << endl;
             uint64_t minchunk, maxchunk;
             minchunk = maxchunk = (snap.size() ? snap[0]->ichunk : 0);
             for (int i=1; i<snap.size(); i++) {
@@ -311,7 +309,7 @@ intensity_network_stream::get_statistics() {
             }
             m["ringbuf_chunk_min"] = minchunk;
             m["ringbuf_chunk_max"] = maxchunk;
-            cout << "Ring buffer chunk range: " << minchunk << " to " << maxchunk << endl;
+            //cout << "Ring buffer chunk range: " << minchunk << " to " << maxchunk << endl;
         }
         R.push_back(m);
     }

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -478,6 +478,7 @@ void intensity_network_stream::_network_thread_body()
 
 	    if (this->stream_end_requested) {
 		pthread_mutex_unlock(&this->state_lock);    
+                _network_flush_packets();
 		return;
 	    }
 

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -296,6 +296,9 @@ intensity_network_stream::get_statistics() {
     m["nbeams"] = nbeams;
     R.push_back(m);
 
+    // Report per-host packet counts
+    R.push_back(this->get_perhost_packets());
+
     // Collect statistics per beam:
     for (int b=0; b<nbeams; b++) {
         m.clear();

--- a/site/Makefile.local.dstn_laptop
+++ b/site/Makefile.local.dstn_laptop
@@ -17,7 +17,12 @@ HDF5_LIB_DIR=/usr/local/lib
 # Don't forget -std=c++11 -pthread -fPIC
 # Don't forget -march=native, since we now use assembly-lagnuage kernels
 #
-CPP=clang++ -std=c++11 -stdlib=libc++ -pthread -fPIC -march=native -Wall -O3 -ffast-math -funroll-loops -I. -I$(INCDIR) -I$(HDF5_INC_DIR)
+DEBUG ?= no
+ifeq ($(DEBUG),no)
+  CPP=clang++ -std=c++11 -stdlib=libc++ -pthread -fPIC -march=native -Wall -O3 -ffast-math -funroll-loops -I. -I$(INCDIR) -I$(HDF5_INC_DIR)
+else
+  CPP=clang++ -std=c++11 -stdlib=libc++ -pthread -fPIC -march=native -Wall -O0 -g -ffast-math -funroll-loops -I. -I$(INCDIR) -I$(HDF5_INC_DIR)
+endif
 
 # Any C++ flags which should only be specified when linking 
 # Don't forget to put -L. and -L$(LIBDIR) on the command line (in this order)

--- a/test-assembled-chunk-hdf5-file.cpp
+++ b/test-assembled-chunk-hdf5-file.cpp
@@ -2,6 +2,9 @@
 #include <iostream>
 #include "ch_frb_io.hpp"
 
+#include "assembled_chunk_msgpack.hpp"
+
+
 using namespace std;
 using namespace ch_frb_io;
 
@@ -31,6 +34,8 @@ int main(int argc, char **argv)
     chunk->randomize(rng);
 
     chunk->write_hdf5_file(string(filename));
+
+    chunk->write_msgpack_file("test_assembled_chunk.msgpack");
     
     return 0;
 }

--- a/test-assembled-chunk-hdf5-file.cpp
+++ b/test-assembled-chunk-hdf5-file.cpp
@@ -31,7 +31,6 @@ int main(int argc, char **argv)
     chunk->randomize(rng);
 
     chunk->write_hdf5_file(string(filename));
-
     
     return 0;
 }

--- a/test-assembled-chunk-hdf5-file.cpp
+++ b/test-assembled-chunk-hdf5-file.cpp
@@ -1,0 +1,37 @@
+#include <cassert>
+#include <iostream>
+#include "ch_frb_io.hpp"
+
+using namespace std;
+using namespace ch_frb_io;
+
+int main(int argc, char **argv)
+{
+    /*
+     cout << "Warning: this will create a ~100 MB file in the current directory!\n"
+     << "If this is OK press return.  If not, press control-C!\n"
+     << "I AM WAITING, HUMAN: "
+     << flush;
+    string dummy;
+    getline(cin, dummy);
+     */
+
+    const char *filename = "test_assembled_chunk.hdf5";
+
+    uint64_t beam_id = 42;
+    int nupfreq = 16;
+    int nt_per_packet = 16;
+    int fpga_counts_per_sample = 400;
+    uint64_t ichunk = 1000;
+
+    std::random_device rd;
+    std::mt19937 rng(rd());
+
+    shared_ptr<assembled_chunk> chunk = assembled_chunk::make(beam_id, nupfreq, nt_per_packet, fpga_counts_per_sample, ichunk);
+    chunk->randomize(rng);
+
+    chunk->write_hdf5_file(string(filename));
+
+    
+    return 0;
+}


### PR DESCRIPTION
These changes include:

* in intensity_network_stream: record IP address & port of packet senders; add accessor for these counts, intensity_network_stream::get_perhost_packets()
* add assembled_chunk::write_hdf5_file()
* add assembled_chunk_ringbuf::get_ringbuf_snapshot() to copy the current ring buffer
* add intensity_network_stream::get_statistics() to compute string-to-int dictionaries with stats on the streams
* add bind_port to intensity_network_ostream ini_params to optionally allow binding L0 udp port number (handy for debugging)

