### PR TITLE
Add Travis-CI continuous-integration, and Coveralls coverage checking services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ dist: trusty
 # use containerized infrastructure (for faster startup; no sudo)
 sudo: false
 
-
 language: cpp
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ addons:
   apt:
     packages:
       - libhdf5-dev
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 # Travis-CI.org build script
 
-# Default environment is Ubuntu 12.04.5 LTS "precise"
-# which is pretty old.
+# Default travis-CI environment is Ubuntu 12.04.5 LTS "precise"
+# which is pretty old:
 # (gcc 4.6.3, which doesn't know about -std=c++11
 #  and fails with
 #  ch_frb_io.hpp:279:28: sorry, unimplemented: non-static data member initializers
 #  ch_frb_io.hpp:279:28: error: ISO C++ forbids in-class initialization of non-const static member 'udp_port'
+# )
 
 # "trusty" is Ubuntu 14.04.5 LTS
 # gcc 4.8.4
+# and compiles our code just fine.  Use that!
 
 dist: trusty
 
@@ -21,16 +23,23 @@ compiler:
   - gcc
   - clang
 
+before_install:
+  - pip install --user cpp-coveralls
+
 script:
-    - pwd
-    - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:~/chime/lib
-    - ln -s site/Makefile.local.travis Makefile.local
-    - make
-    - make install
-    - ./test-intensity-hdf5-file yes
-    - ./test-misc
-    # Takes an hour...
-    # - ./test-network-streams
+  - pwd
+  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:~/chime/lib
+  - ln -s site/Makefile.local.travis Makefile.local
+  - make
+  - make install
+  - ./test-intensity-hdf5-file yes
+  - ./test-misc
+  - ./test-assembled-chunk
+  # Takes an hour...
+  # - ./test-network-streams
+
+after_success:
+  - coveralls --exclude lib --exclude tests --gcov-options '\-lp'
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - make COVERAGE=yes OPTIMIZE=no
   - make install
   - ./test-intensity-hdf5-file yes
-  - ./test-assembled-chunk
+  #- ./test-assembled-chunk
   # Some tests are too slow to run with -O0...
   - make clean
   - make COVERAGE=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ script:
     - make install
     - ./test-intensity-hdf5-file yes
     - ./test-misc
-    - ./test-network-streams
+    # Takes an hour...
+    # - ./test-network-streams
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
 addons:
   apt:
     packages:
-      - libhdf5-dev
+      - libhdf5-serial-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 # Travis-CI.org build script
 
-# use the new containerized infrastructure
+# Default environment is Ubuntu 12.04.5 LTS "precise"
+# which is pretty old.
+
+dist: trusty
+
+# use containerized infrastructure (for faster startup; no sudo)
 sudo: false
+
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Travis-CI.org build script
+
+# use the new containerized infrastructure
+sudo: false
+
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+script:
+    - ln -s site/Makefile.local.travis Makefile.local
+    - make
+    - ./test-intensity-hdf5-file
+    - ./test-misc
+    - ./test-network-streams
+
+addons:
+  apt:
+    packages:
+      - libhdf5-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,14 @@ script:
   - pwd
   - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:~/chime/lib
   - ln -s site/Makefile.local.travis Makefile.local
-  - make
+  - make COVERAGE=yes OPTIMIZE=no
   - make install
   - ./test-intensity-hdf5-file yes
-  - ./test-misc
   - ./test-assembled-chunk
+  # Some tests are too slow to run with -O0...
+  - make clean
+  - make COVERAGE=yes
+  - ./test-misc
   # Takes an hour...
   # - ./test-network-streams
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@
 
 # Default environment is Ubuntu 12.04.5 LTS "precise"
 # which is pretty old.
+# (gcc 4.6.3, which doesn't know about -std=c++11
+#  and fails with
+#  ch_frb_io.hpp:279:28: sorry, unimplemented: non-static data member initializers
+#  ch_frb_io.hpp:279:28: error: ISO C++ forbids in-class initialization of non-const static member 'udp_port'
+
+# "trusty" is Ubuntu 14.04.5 LTS
+# gcc 4.8.4
 
 dist: trusty
 
@@ -16,8 +23,11 @@ compiler:
   - clang
 
 script:
+    - pwd
+    - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:~/chime/lib
     - ln -s site/Makefile.local.travis Makefile.local
     - make
+    - make install
     - ./test-intensity-hdf5-file
     - ./test-misc
     - ./test-network-streams

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ script:
   - ./test-intensity-hdf5-file yes
   #- ./test-assembled-chunk
   # Some tests are too slow to run with -O0...
-  - make clean
-  - make COVERAGE=yes
-  - ./test-misc
+  # - make clean
+  # - make COVERAGE=yes
+  # - ./test-misc
   # Takes an hour...
   # - ./test-network-streams
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
     - ln -s site/Makefile.local.travis Makefile.local
     - make
     - make install
-    - ./test-intensity-hdf5-file
+    - ./test-intensity-hdf5-file yes
     - ./test-misc
     - ./test-network-streams
 

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -1,13 +1,13 @@
 # Makefile.local for travis-ci.org continuous integration build
 
 # Directory where C++ libraries will be installed
-LIBDIR=$(HOME)/lib
+LIBDIR=$(HOME)/chime/lib
 
 # Directory where C++ header files will be installed
-INCDIR=$(HOME)/include
+INCDIR=$(HOME)/chime/include
 
 # Directory where executables will be installed
-BINDIR=$(HOME)/bin
+BINDIR=$(HOME)/chime/bin
 
 # HDF5_INC_DIR=/usr/local/include
 # HDF5_LIB_DIR=/usr/local/lib
@@ -24,7 +24,8 @@ CXX ?= g++
 
 ifeq ($(CXX),g++)
 ## g++
-CPP=$(CXX) -std=c++0x -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+#CPP=$(CXX) -std=c++0x -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
 else
 ## clang++
 # No -ffast-math: https://llvm.org/bugs/show_bug.cgi?id=13745

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -22,13 +22,15 @@ BINDIR=$(HOME)/chime/bin
 CXX ?= g++
 #CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
 
-ifeq ($(CXX),g++)
-## g++
-#CPP=$(CXX) -std=c++0x -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
-CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
-else
-## clang++
-# No -ffast-math: https://llvm.org/bugs/show_bug.cgi?id=13745
-CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
-endif
+# ifeq ($(CXX),g++)
+# ## g++
+# #CPP=$(CXX) -std=c++0x -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+# CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+# else
+# ## clang++
+# # No -ffast-math: https://llvm.org/bugs/show_bug.cgi?id=13745
+# CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+# endif
 
+CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR)
+CPP_LFLAGS := -L. -L$(LIBDIR)

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -1,0 +1,24 @@
+# Makefile.local for travis-ci.org continuous integration build
+# (ubuntu)
+
+# Directory where C++ libraries will be installed
+LIBDIR=$(HOME)/lib
+
+# Directory where C++ header files will be installed
+INCDIR=$(HOME)/include
+
+# Directory where executables will be installed
+BINDIR=$(HOME)/bin
+
+# HDF5_INC_DIR=/usr/local/include
+# HDF5_LIB_DIR=/usr/local/lib
+
+#
+# C++ command line
+# Don't forget -std=c++11 -pthread -fPIC
+# Don't forget to put -L. and -L$(LIBDIR) on the command line (in this order)
+# Don't forget to add . and $(LIBDIR) in your LD_LIBRARY_PATH environment variable (in this order)
+#
+
+CXX ?= g++
+CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -34,10 +34,19 @@ CXX ?= g++
 
 #CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR)
 
-#OPT_FLAGS := -O3
-# Travis + Coverall: include coverage tracking code.  Also note that we turned off optimization!
-OPT_FLAGS := -O0 -fprofile-arcs -ftest-coverage
+OPTIMIZE ?= yes
+ifeq ($(OPTIMIZE), yes)
+    OPT_FLAGS := -O3 -funroll-loops
+else
+    OPT_FLAGS := -O0
+endif
 
-CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall $(OPT_FLAGS) -march=native -ffast-math -funroll-loops -I. -I$(INCDIR)
+COVERAGE ?= no
+ifeq ($(COVERAGE), yes)
+    # Travis + Coverall: include coverage tracking code.  Also note that we turned off optimization!
+    OPT_FLAGS += -fprofile-arcs -ftest-coverage
+endif
+
+CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall $(OPT_FLAGS) -march=native -ffast-math -I. -I$(INCDIR)
 
 CPP_LFLAGS := -L. -L$(LIBDIR)

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -21,4 +21,14 @@ BINDIR=$(HOME)/bin
 #
 
 CXX ?= g++
-CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+#CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+
+ifeq ($(CXX),g++)
+## g++
+CPP=$(CXX) -std=c++0x -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+else
+## clang++
+# No -ffast-math: https://llvm.org/bugs/show_bug.cgi?id=13745
+CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
+endif
+

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -1,5 +1,4 @@
 # Makefile.local for travis-ci.org continuous integration build
-# (ubuntu)
 
 # Directory where C++ libraries will be installed
 LIBDIR=$(HOME)/lib

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -32,5 +32,12 @@ CXX ?= g++
 # CPP=$(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -funroll-loops -I. -I$(INCDIR) -L. -L$(LIBDIR)
 # endif
 
-CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR)
+#CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -funroll-loops -I. -I$(INCDIR)
+
+#OPT_FLAGS := -O3
+# Travis + Coverall: include coverage tracking code.  Also note that we turned off optimization!
+OPT_FLAGS := -O0 -fprofile-arcs -ftest-coverage
+
+CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall $(OPT_FLAGS) -march=native -ffast-math -funroll-loops -I. -I$(INCDIR)
+
 CPP_LFLAGS := -L. -L$(LIBDIR)

--- a/test-intensity-hdf5-file.cpp
+++ b/test-intensity-hdf5-file.cpp
@@ -23,13 +23,14 @@ inline double wtval(int ifreq, int ipol, int it)
 
 int main(int argc, char **argv)
 {
-    cout << "Warning: this will create a ~100 MB file in the current directory!\n"
-	 << "If this is OK press return.  If not, press control-C!\n"
-	 << "I AM WAITING, HUMAN: "
-	 << flush;
-    
-    string dummy;
-    getline(cin, dummy);
+    if (argc == 1) {
+        cout << "Warning: this will create a ~100 MB file in the current directory!\n"
+             << "If this is OK press return.  If not, press control-C!\n"
+             << "I AM WAITING, HUMAN: "
+             << flush;
+        string dummy;
+        getline(cin, dummy);
+    }
 
     const char *filename = "test_intensity_hdf5_file.hdf5";
     const int nfreq = 1024;


### PR DESCRIPTION
Adds integration with:

* travis-ci.org, which does continuous-integration: builds our code and runs tests on each commit and notifies us when the build is broken
* coveralls.io, which tracks test coverage statistics

eg,

https://travis-ci.org/dstndstn/ch_frb_io
https://coveralls.io/github/dstndstn/ch_frb_io

