### PR TITLE
Retrieve more statistics from network & assembler threads and ring buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ OFILES = assembled_chunk.o \
 	intensity_network_ostream.o \
 	intensity_packet.o \
 	lexical_cast.o \
+	misc.o \
 	udp_packet_list.o \
 	udp_packet_ringbuf.o \
 	bitshuffle/bitshuffle.o \

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -174,6 +174,12 @@ bool assembled_chunk_ringbuf::_put_assembled_chunk(unique_ptr<assembled_chunk> &
     if (sch) {
 	pthread_cond_broadcast(&this->cond_assembled_chunks_added);
 	pthread_mutex_unlock(&this->lock);
+
+        // Call any callbacks for chunks being added.
+        for (auto it=chunk_callbacks.begin(); it!=chunk_callbacks.end(); it++) {
+            (*it)(sch);
+        }
+
         if (event_counts)
             event_counts[intensity_network_stream::event_type::assembled_chunk_queued]++;
 	return true;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -35,6 +35,7 @@ assembled_chunk_ringbuf::assembled_chunk_ringbuf(const intensity_network_stream:
 	throw runtime_error("ch_frb_io: the 'mandate_fast_kernels' flag was set, but this machine does not have the AVX2 instruction set");
 #endif
 
+    // Note that 
     ringbuf = new L1Ringbuf(beam_id_, ini_params.ringbuf_n);
 
     uint64_t packet_t0 = fpga_count0 / fpga_counts_per_sample;
@@ -238,14 +239,11 @@ void assembled_chunk_ringbuf::end_stream(int64_t *event_counts)
     if (!active_chunk0 || !active_chunk1)
 	throw runtime_error("ch_frb_io: internal error: empty pointers in assembled_chunk_ringbuf::end_stream(), this can happen if end_stream() is called twice");
 
-    if (active_chunk0) {
-        cout << "assembled_chunk_ringbuf::end_stream: putting chunk0 " << active_chunk0->ichunk << endl;
+    if (active_chunk0)
         this->_put_assembled_chunk(active_chunk0, event_counts);
-    }
-    if (active_chunk1) {
-        cout << "assembled_chunk_ringbuf::end_stream: putting chunk1 " << active_chunk1->ichunk << endl;
+
+    if (active_chunk1)
         this->_put_assembled_chunk(active_chunk1, event_counts);
-    }
 
     pthread_mutex_lock(&this->lock);
 

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -169,9 +169,9 @@ bool assembled_chunk_ringbuf::_put_assembled_chunk(unique_ptr<assembled_chunk> &
     // Convert unique_ptr into bare pointer, and reset unique_ptr.
     assembled_chunk* ch = chunk.release();
     // Try to add to ringbuf...
-    bool added = ringbuf->push(ch);
+    shared_ptr<assembled_chunk> sch = ringbuf->push(ch);
 
-    if (added) {
+    if (sch) {
 	pthread_cond_broadcast(&this->cond_assembled_chunks_added);
 	pthread_mutex_unlock(&this->lock);
         if (event_counts)

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -55,6 +55,11 @@ assembled_chunk_ringbuf::~assembled_chunk_ringbuf()
     delete ringbuf;
 }
 
+void assembled_chunk_ringbuf::print_state() {
+    cout << "Beam " << beam_id << endl;
+    ringbuf->print();
+}
+
 vector<shared_ptr<assembled_chunk> >
 assembled_chunk_ringbuf::get_ringbuf_snapshot(uint64_t min_fpga_counts,
                                               uint64_t max_fpga_counts)

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -60,11 +60,11 @@ void assembled_chunk_ringbuf::print_state() {
     ringbuf->print();
 }
 
-vector<shared_ptr<assembled_chunk> >
+vector<pair<shared_ptr<assembled_chunk>, uint64_t> >
 assembled_chunk_ringbuf::get_ringbuf_snapshot(uint64_t min_fpga_counts,
                                               uint64_t max_fpga_counts)
 {
-    vector<shared_ptr<assembled_chunk> > chunks;
+    vector<pair<shared_ptr<assembled_chunk>, uint64_t> > chunks;
     pthread_mutex_lock(&this->lock);
     ringbuf->retrieve(min_fpga_counts, max_fpga_counts, chunks);
     pthread_mutex_unlock(&this->lock);

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <memory>
 #include <random>
+#include <thread>
 #include <hdf5.h>
 
 namespace ch_frb_io {
@@ -412,8 +413,9 @@ protected:
     // Used only by the assembler thread
     std::vector<int64_t> assembler_thread_event_subcounts;
 
-    pthread_t network_thread;
-    pthread_t assembler_thread;
+    std::thread network_thread;
+    std::thread assembler_thread;
+
     char _pad3[constants::cache_line_size];
 
     // State model.  These flags are protected by the state_lock and are set in sequence.
@@ -448,8 +450,8 @@ protected:
     void _network_flush_packets();
     void _add_event_counts(std::vector<int64_t> &event_subcounts);
 
-    static void *network_pthread_main(void *);
-    static void *assembler_pthread_main(void *);
+    void network_thread_main();
+    void assembler_thread_main();
 
     // Private methods called by the network thread.    
     void _network_thread_body();

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -348,9 +348,10 @@ public:
     std::vector< std::vector< std::shared_ptr<assembled_chunk> > > get_ringbuf_snapshots(std::vector<uint64_t> &beams,
                                                                                          uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 
-    // For debugging/testing purposes: pretend that the given assembled_chunk
-    // has just arrived.
-    void inject_assembled_chunk(assembled_chunk* chunk);
+    // For debugging/testing purposes: pretend that the given
+    // assembled_chunk has just arrived.  Returns true if there was
+    // room in the ring buffer for the new chunk.
+    bool inject_assembled_chunk(assembled_chunk* chunk);
 
     // For debugging/testing: stream data to disk.  Filename pattern: see assembled_chunk::format_filename.  Empty string to turn off streaming.
     void stream_to_files(const std::string& filename_pattern);

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -399,6 +399,8 @@ protected:
     std::atomic<uint64_t> network_thread_waiting_usec;
     std::atomic<uint64_t> network_thread_working_usec;
 
+    std::atomic<uint64_t> socket_queued_bytes;
+
     // I'm not sure how much it actually helps bottom-line performace, but it seemed like a good idea
     // to insert padding so that data accessed by different threads is in different cache lines.
     char _pad1[constants::cache_line_size];

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -644,6 +644,7 @@ public:
 	float wt_cutoff = constants::default_wt_cutoff;
 	double target_gbps = constants::default_gbps;   // if 0.0, then data will be written as quickly as possible!
         int bind_port = 0; // 0: don't bind; send from randomly assigned port
+        std::string bind_ip = "0.0.0.0";
 
 	bool is_blocking = true;
 	bool emit_warning_on_buffer_drop = true;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -345,8 +345,13 @@ public:
 
     std::vector<std::unordered_map<std::string, uint64_t> > get_statistics();
 
-    std::vector< std::vector< std::shared_ptr<assembled_chunk> > > get_ringbuf_snapshots(std::vector<uint64_t> &beams,
-                                                                                         uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
+    // Retrieves chunks from one or more ring buffers.  The uint64_t
+    // return value is a bitmask of l1_ringbuf_level values saying
+    // where in the ringbuffer the chunk was found; this is an
+    // implementation detail revealed for debugging purposes
+    std::vector< std::vector< std::pair<std::shared_ptr<assembled_chunk>, uint64_t> > >
+    get_ringbuf_snapshots(std::vector<uint64_t> &beams,
+                          uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 
     // For debugging/testing purposes: pretend that the given
     // assembled_chunk has just arrived.  Returns true if there was

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <functional>
 #include <unordered_map>
 #include <memory>
 #include <cstdint>
@@ -364,6 +365,12 @@ public:
     // For debugging/testing: stream data to disk.  Filename pattern: see assembled_chunk::format_filename.  Empty string to turn off streaming.
     void stream_to_files(const std::string& filename_pattern);
 
+    // For debugging/testing: request that the given callback be
+    // called each time an assembled_chunk is enqueued in the ring
+    // buffer.
+    void add_assembled_chunk_callback(std::function<void(std::shared_ptr<assembled_chunk>)> callback);
+    //void remove_assembled_chunk_callback(std::function<void(std::shared_ptr<assembled_chunk>)> callback);
+
     // For debugging: print state.
     void print_state();
 
@@ -453,6 +460,8 @@ protected:
     std::unordered_map<uint64_t, uint64_t> perhost_packets;
 
     std::string stream_filename;
+
+    std::vector<std::function<void(std::shared_ptr<assembled_chunk>)> > chunk_callbacks;
 
     // The actual constructor is protected, so it can be a helper function 
     // for intensity_network_stream::make(), but can't be called otherwise.

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -355,6 +355,9 @@ public:
     // For debugging/testing: stream data to disk.  Filename pattern: see assembled_chunk::format_filename.  Empty string to turn off streaming.
     void stream_to_files(const std::string& filename_pattern);
 
+    // For debugging: print state.
+    void print_state();
+
     ~intensity_network_stream();
 
 protected:

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -425,8 +425,6 @@ protected:
 
     pthread_mutex_t state_lock;
     pthread_cond_t cond_state_changed;       // threads wait here for state to change
-    bool assembler_thread_started = false;   // set by assembler thread on startup
-    bool network_thread_started = false;     // set by network thread on startup
     bool stream_started = false;             // set asynchonously by calling start_stream()
     bool first_packet_received = false;      // set by network thread
     bool assemblers_initialized = false;     // set by assembler thread

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
+#include <cstdint>
 #include <atomic>
 #include <random>
 #include <thread>
@@ -395,12 +396,18 @@ protected:
 
     // Written by network thread, read by outside thread
     // How much wall time do we spend waiting in recvfrom() vs processing?
-    std::atomic_uint64_t network_thread_recv_usec;
-    std::atomic_uint64_t network_thread_processing_usec;
+    std::atomic<uint64_t> network_thread_waiting_usec;
+    std::atomic<uint64_t> network_thread_working_usec;
 
     // I'm not sure how much it actually helps bottom-line performace, but it seemed like a good idea
     // to insert padding so that data accessed by different threads is in different cache lines.
     char _pad1[constants::cache_line_size];
+
+    // Written by assembler thread, read by outside thread
+    std::atomic<uint64_t> assembler_thread_waiting_usec;
+    std::atomic<uint64_t> assembler_thread_working_usec;
+
+    char _pad1b[constants::cache_line_size];
 
     // Used only by the network thread (not protected by lock)
     //

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -253,7 +253,7 @@ public:
     void end_stream(int64_t *event_counts);
 
     // Debugging: inject the given chunk
-    void inject_assembled_chunk(assembled_chunk* chunk);
+    bool inject_assembled_chunk(assembled_chunk* chunk);
 
     // Debugging: print state
     void print_state();
@@ -293,7 +293,7 @@ protected:
 
     // Helper function: adds assembled chunk to the ring buffer
     // Post-condition: chunk has been reset().
-    void _put_assembled_chunk(std::unique_ptr<assembled_chunk> &chunk, int64_t *event_counts);
+    bool _put_assembled_chunk(std::unique_ptr<assembled_chunk> &chunk, int64_t *event_counts);
 
     // Helper function: allocates new assembled chunk
     std::unique_ptr<assembled_chunk> _make_assembled_chunk(uint64_t ichunk);

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -285,6 +285,9 @@ public:
     // Are we streaming data to disk?
     std::string stream_filename_pattern;
 
+    // Debugging: callbacks for each enqueued assembled_chunk.
+    std::vector< std::function<void(std::shared_ptr<assembled_chunk>)> > chunk_callbacks;
+
 protected:
     const intensity_network_stream::initializer ini_params;
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -62,11 +62,15 @@ struct intensity_packet {
     uint8_t   *data;              // array of shape (nbeam, nfreq_coarse, nupfreq, ntsamp)
 
 
+    static inline int header_size(int nbeams, int nfreq_coarse)
+    {
+	return 24 + 2*nbeams + 2*nfreq_coarse + 8*nbeams*nfreq_coarse;
+    }
+
     static inline int packet_size(int nbeams, int nfreq_coarse, int nupfreq, int nt_per_packet)
     {
-	int header_size = 24 + 2*nbeams + 2*nfreq_coarse + 8*nbeams*nfreq_coarse;
 	int data_size = nbeams * nfreq_coarse * nupfreq * nt_per_packet;
-	return header_size + data_size;
+	return header_size(nbeams, nfreq_coarse) + data_size;
     }
 
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -203,6 +203,8 @@ struct udp_packet_ringbuf : noncopyable {
     // Throws an exception if called after end-of-stream.
     bool put_packet_list(std::unique_ptr<udp_packet_list> &p, bool is_blocking);
 
+    void get_size(int* currsize, int* maxsize);
+
     // Note!  The pointer 'p' is _swapped_ with the udp_packet_list which is extracted from the ring buffer.
     // In other words, when get_packet_list() returns, the original udp_packet_list will be "recycled" (rather than freed).
     // Returns true on success (possibly after blocking), returns false if ring buffer is empty and stream has ended.

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -264,7 +264,7 @@ public:
     // to indicate end-of-stream.
     std::shared_ptr<assembled_chunk> get_assembled_chunk(bool wait=true);
 
-    std::vector<std::shared_ptr<assembled_chunk> > get_ringbuf_snapshot(uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
+    std::vector<std::pair<std::shared_ptr<assembled_chunk>, uint64_t> > get_ringbuf_snapshot(uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 
     // Returns stats about the ring buffer.
     //  *ringbuf_fpga_next* is the FPGA-counts of the next chunk that will be delivered to get_assembled_chunk().

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -255,6 +255,9 @@ public:
     // Debugging: inject the given chunk
     void inject_assembled_chunk(assembled_chunk* chunk);
 
+    // Debugging: print state
+    void print_state();
+
     // Called by processing threads, via intensity_network_stream::get_assembled_chunk().
     // Returns the next assembled_chunk from the ring buffer, blocking if necessary to wait for data.
     // If the ring buffer is empty and end_stream() has been called, it returns an empty pointer

--- a/chlog.hpp
+++ b/chlog.hpp
@@ -39,7 +39,7 @@ chime_logf(enum log_level lev, const char* file, int line, const char* function,
     do {                                                                \
         std::ostringstream ss;                                          \
         ss << __VA_ARGS__;                                              \
-        chime_log(log_level_info, __FILE__, __LINE__, __PRETTY_FUNCTION__, ss.str()); \
+        chime_log(ch_frb_io::log_level_info, __FILE__, __LINE__, __PRETTY_FUNCTION__, ss.str()); \
     } while(0)
 
 // Like chlog, but takes a printf-style format string and arguments.

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -211,9 +211,15 @@ void intensity_network_ostream::_open_socket()
         struct sockaddr_in server_address;
         memset(&server_address, 0, sizeof(server_address));
         server_address.sin_family = AF_INET;
-        inet_pton(AF_INET, "0.0.0.0", &server_address.sin_addr);
+        int err = inet_pton(AF_INET, ini_params.bind_ip.c_str(), &server_address.sin_addr);
+        if (err != 1) {
+            string errstr = "ch_frb_io: failed to parse bind_ip: \"" + ini_params.bind_ip + "\"";
+            if (err == -1)
+                errstr += ": " + string(strerror(errno));
+            throw runtime_error(errstr);
+        }
         server_address.sin_port = htons(ini_params.bind_port);
-        int err = ::bind(sockfd, (struct sockaddr *) &server_address, sizeof(server_address));
+        err = ::bind(sockfd, (struct sockaddr *) &server_address, sizeof(server_address));
         if (err < 0)
             throw runtime_error(string("ch_frb_io: bind() failed: ") + strerror(errno));
     }

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -95,10 +95,15 @@ intensity_network_ostream::intensity_network_ostream(const initializer &ini_para
 	throw runtime_error("chime intensity_network_ostream constructor: bad value of nupfreq (or uninitalized)");
     if ((fpga_counts_per_sample <= 0) || (fpga_counts_per_sample > constants::max_allowed_fpga_counts_per_sample))
 	throw runtime_error("chime intensity_network_ostream constructor: bad value of fpga_counts_per_sample (or uninitialized)");
+
     if (ini_params.wt_cutoff <= 0.0)
 	throw runtime_error("chime intensity_network_ostream constructor: expected wt_cutoff to be > 0");
-    if (target_gbps < 0.0)
-	throw runtime_error("chime intensity_network_ostream constructor: expected target_gbps to be >= 0.0");
+    if (ini_params.target_gbps < 0.0)
+	throw runtime_error("ch_frb_io::intensity_network_ostream::initializer::target_gbps is negative");
+    if (ini_params.target_gbps > constants::max_allowed_output_gbps)
+	throw runtime_error("ch_frb_io::intensity_network_ostream::initializer::target_gbps is > max_allowed_output_gbps, presumably unintentional");
+    if (!ini_params.throttle && (ini_params.target_gbps != 0.0))
+	throw runtime_error("ch_frb_io::intensity_network_ostream::initializer::throttle is false, but target_gbps is nonzero, suspect this is a misconfiguration");
 
     if (nbytes_per_packet > constants::max_output_udp_packet_size)
 	throw runtime_error("chime intensity_network_ostream constructor: packet size is too large, you need to decrease nfreq_per_packet or nt_per_packet");
@@ -117,6 +122,18 @@ intensity_network_ostream::intensity_network_ostream(const initializer &ini_para
 	for (unsigned int j = 0; j < i; j++)
 	    if (ini_params.coarse_freq_ids[i] == ini_params.coarse_freq_ids[j])
 		throw runtime_error("intensity_network_ostream constructor: duplicate coarse_freq_id");
+    }
+
+    if (ini_params.throttle && (target_gbps == 0.0)) {
+	// Infer target_gbps from fpga_counts_per_sample.
+	double num = (8.0e-9 * nbytes_per_packet) * (nfreq_coarse_per_chunk / nfreq_coarse_per_packet);   // gigabits
+	double den = (fpga_counts_per_packet * constants::dt_fpga);    // seconds
+	this->target_gbps = num / den;
+    }
+
+    if (target_gbps > constants::max_allowed_output_gbps) {
+	throw runtime_error("ch_frb_io::intensity_network_ostream:: inferred target_gbps(=" + to_string(target_gbps)
+			    + ") is > max_allowed_output_gbps(=" + to_string(constants::max_allowed_output_gbps) + ")");
     }
 
     // Parse dstname (expect string of the form HOSTNAME[:PORT])
@@ -202,7 +219,7 @@ void intensity_network_ostream::_open_socket()
     if (sockfd < 0)
 	throw runtime_error(string("ch_frb_io: couldn't create udp socket: ") + strerror(errno));
 
-    int socket_bufsize = constants::send_socket_bufsize;
+    int socket_bufsize = constants::default_socket_bufsize;
     err = setsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, (void *) &socket_bufsize, sizeof(socket_bufsize));
     if (err < 0)
 	throw runtime_error(string("ch_frb_io: setsockopt(SO_SNDBUF) failed: ") + strerror(errno));
@@ -336,7 +353,8 @@ void *intensity_network_ostream::network_pthread_main(void *opaque_arg)
 
     try {
 	stream->_network_thread_body();
-    } catch (...) {
+    } catch (exception &e) {
+	cerr << e.what() << endl;
 	stream->end_stream(false);   // "false" means "don't join threads" (would deadlock otherwise!)
 	throw;
     }
@@ -354,10 +372,29 @@ void intensity_network_ostream::_network_thread_body()
     pthread_mutex_unlock(&state_lock);
 
     auto packet_list = make_unique<udp_packet_list> (npackets_per_chunk, nbytes_per_chunk);
-    int last_packet_nbytes = 0;
-
-    // to be initialized when first packet is sent
+    
+    // To be initialized when first packet is sent.
     struct timeval tv_ini;
+
+    // Thread-local timestamps and counters.  
+    //
+    // Note that 'class intensity_network_ostream' defines three thread-shared members, which
+    // will be kept in sync with their thread-local counterparts:
+    //
+    //    curr_timestamp <-> tstamp
+    //    npackets_sent  <-> npackets_tot
+    //    nbytes_sent    <-> nbytes_tot
+    //
+    // At the bottom of the packet loop below, we acquire the lock and update the thread-shared
+    // versions.  In the body of the loop, we use the thread-locals so that we don't need
+    // to acquire the lock repeatedly.  This scheme is safe because these variables are only 
+    // modified by the network thread (i.e. other threads only access them read-only).
+
+    int64_t prev_packet_nbytes = 0;
+    int64_t prev_tstamp = 0;
+    int64_t nbytes_tot = 0;     // not to be confused with thread-shared variable this->nbytes_sent
+    int64_t npackets_tot = 0;   // not to be confused with this->npackets_sent
+    int64_t tstamp = 0;         // not to be confused with this->curr_timestamp
     
     // Loop over packet_lists
     for (;;) {
@@ -369,23 +406,29 @@ void intensity_network_ostream::_network_thread_body()
 	    const uint8_t *packet = packet_list->get_packet_data(ipacket);
 	    const int packet_nbytes = packet_list->get_packet_nbytes(ipacket);
 
-            pthread_mutex_lock(&statistics_lock);
-	    if (npackets_sent == 0)
+	    if (npackets_tot == 0)
 		tv_ini = xgettimeofday();
 
-	    int64_t last_timestamp = this->curr_timestamp;
-            int64_t tstamp = this->curr_timestamp = usec_between(tv_ini, xgettimeofday());
-            int64_t npackets = this->npackets_sent;
-            pthread_mutex_unlock(&statistics_lock);
+	    tstamp = usec_between(tv_ini, xgettimeofday());
 
 	    // Throttling logic: compare actual bandwidth to 'target_gbps' and sleep if necessary.
-	    if ((target_gbps > 0.0) && (npackets > 0)) {
-		int64_t target_timestamp = last_timestamp + int64_t(8.0e-3 * last_packet_nbytes / target_gbps);		
+	    //
+	    // t1 = "global" target timestamp based on cumulative transmission so far.  In normal
+	    //      operation this will determine the time when the new packet is sent.
+	    //
+	    // t2 = "local" target timestamp based on transmission time of previous packet.  We
+	    //      compute this below with a fudge factor of 0.8.  The idea is that in a situation
+	    //      where the cumulative transfer has fallen behind, we can temporarily transmit
+	    //      20% faster while we catch up.
+
+	    if ((target_gbps > 0.0) && (npackets_tot > 0)) {
+		int64_t t1 = 8.0e-3 * nbytes_tot / target_gbps;
+		int64_t t2 = prev_tstamp + int64_t(0.8 * 8.0e-3 * prev_packet_nbytes / target_gbps);
+		int64_t target_timestamp = max(t1,t2);
+
 		if (tstamp < target_timestamp) {
 		    xusleep(target_timestamp - tstamp);
-                    pthread_mutex_lock(&statistics_lock);
-		    curr_timestamp = target_timestamp;
-                    pthread_mutex_unlock(&statistics_lock);
+		    tstamp = target_timestamp;
 		}
 	    }
 
@@ -395,15 +438,25 @@ void intensity_network_ostream::_network_thread_body()
 	    if (n != packet_nbytes)
 		throw runtime_error(string("chime intensity_network_ostream: udp packet send() sent ") + to_string(n) + "/" + to_string(packet_nbytes) + " bytes?!");
 
-	    last_packet_nbytes = packet_nbytes;
+	    prev_packet_nbytes = packet_nbytes;
+	    prev_tstamp = tstamp;
+	    nbytes_tot += packet_nbytes;
+	    npackets_tot++;
+
+	    // Keep thread-shared variables in sync with thread-locals, as described above.
             pthread_mutex_lock(&statistics_lock);
-	    this->nbytes_sent += packet_nbytes;
-	    this->npackets_sent++;
+	    this->curr_timestamp = tstamp;
+	    this->nbytes_sent = nbytes_tot;
+	    this->npackets_sent = npackets_tot;
             pthread_mutex_unlock(&statistics_lock);
 	}
     }
 
-    this->_announce_end_of_stream();
+    if (ini_params.send_end_of_stream_packets)
+	this->_send_end_of_stream_packets();
+
+    if (ini_params.print_status_at_end)
+	this->print_status();
 }
 
 ssize_t intensity_network_ostream::_send(int socket, const uint8_t* packet, int nbytes, int flags) {
@@ -421,18 +474,16 @@ void intensity_network_ostream::get_statistics(int64_t& curr_timestamp,
 }
 
 
-void intensity_network_ostream::_announce_end_of_stream()
+void intensity_network_ostream::_send_end_of_stream_packets()
 {
     // Send end-of-stream packets.  (This isn't part of the packet protocol, but the network _input_
     // stream contains an option to shut down gracefully if a special packet with nbeams=nupfreq=nt=0
     // is received.)
     //
     // Since UDP doesn't guarantee delivery, we have no way to ensure that the end-of-stream packet 
-    // reaches the other side, but we'll make a best effort by sending 10 packets separated by 0.1 sec.
+    // reaches the other side, but we'll make a best effort by sending 5 packets separated by 0.1 sec.
 
-    cerr << "ch_frb_io: network output thread sending end-of-stream packets\n";
-
-    for (int ipacket = 0; ipacket < 10; ipacket++) {
+    for (int ipacket = 0; ipacket < 5; ipacket++) {
 	vector<uint8_t> packet(24, uint8_t(0));
 	*((uint32_t *) &packet[0]) = uint32_t(1);  // protocol number
 
@@ -452,18 +503,38 @@ void intensity_network_ostream::_announce_end_of_stream()
 
 	break;
     }
+}
 
-    // End-of-stream summary info
+
+void intensity_network_ostream::print_status(ostream &os)
+{
+    int64_t tstamp = 0;
+    int64_t npackets = 0;
+    int64_t nbytes = 0;
+
+    this->get_statistics(tstamp, npackets, nbytes);
+
+    // Gather output into a single contiguous C-string, in order
+    // to reduce probability of interleaved output in multithreaded case.
 
     stringstream ss;
-    ss << "ch_frb_io: network output thread exiting, npackets_sent=" << npackets_sent;
-    if (npackets_sent >= 2)
-	ss << ", gbps=" << (8.0e-3 * nbytes_sent / double(curr_timestamp));
+
+    ss << "ch_frb_io output stream: dst=" << ini_params.dstname
+       << ", nbeams=" << nbeams << ", nfreq_coarse=" << nfreq_coarse_per_chunk
+       << ", npackets=" << npackets;
+
+    if (npackets >= 2)
+	ss << ", gbps=" << (8.0e-3 * nbytes / double(tstamp));
+
     if (target_gbps > 0.0)
 	ss << ", target_gbps=" << target_gbps;
+
     ss << "\n";
 
-    cerr << ss.str();
+    string s = ss.str();
+    const char *cstr = s.c_str();
+
+    os << cstr;
 }
 
 

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -489,7 +489,7 @@ bool intensity_network_stream::get_first_packet_params(int &nupfreq, int &nt_per
 
 void intensity_network_stream::network_thread_main() {
 
-    pin_thread_to_cores(stream->ini_params.network_thread_cores);
+    pin_thread_to_cores(ini_params.network_thread_cores);
 
     // We use try..catch to ensure that _network_thread_exit() always gets called, even if an exception is thrown.
     // We also print the exception so that it doesn't get "swallowed".
@@ -727,7 +727,7 @@ void intensity_network_stream::_put_unassembled_packets()
 
 void intensity_network_stream::assembler_thread_main() {
 
-    pin_thread_to_cores(stream->ini_params.assembler_thread_cores);
+    pin_thread_to_cores(ini_params.assembler_thread_cores);
 
     // We use try..catch to ensure that _assembler_thread_exit() always gets called, even if an exception is thrown.
     // We also print the exception so that it doesn't get "swallowed".

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -836,7 +836,7 @@ void intensity_network_stream::_assembler_thread_body()
     }
 }
 
-void intensity_network_stream::inject_assembled_chunk(assembled_chunk* chunk) {
+bool intensity_network_stream::inject_assembled_chunk(assembled_chunk* chunk) {
 
     pthread_mutex_lock(&this->state_lock);
     if (!first_packet_received) {
@@ -858,10 +858,11 @@ void intensity_network_stream::inject_assembled_chunk(assembled_chunk* chunk) {
     const int *assembler_beam_ids = &ini_params.beam_ids[0];
     for (int i = 0; i < nassemblers; i++) {
         if (assembler_beam_ids[i] == chunk->beam_id) {
-            assemblers[i]->inject_assembled_chunk(chunk);
-            break;
+            return assemblers[i]->inject_assembled_chunk(chunk);
         }
     }
+    cout << "inject_assembled_chunk: no match for beam " << chunk->beam_id << endl;
+    return false;
 }
 
 // Called whenever the assembler thread exits (on all exit paths)

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -377,17 +377,18 @@ bool intensity_network_stream::get_first_packet_params(int &nupfreq, int &nt_per
 {
     pthread_mutex_lock(&this->state_lock);
 
-    while (!this->first_packet_received)
+    while (!this->first_packet_received) {
 	pthread_cond_wait(&this->cond_state_changed, &this->state_lock);
     
-    if (this->stream_end_requested) {
-	// end_stream() was called before first packet was received
-	pthread_mutex_unlock(&this->state_lock);
-	nupfreq = 0;
-	nt_per_packet = 0;
-	fpga_counts_per_sample = 0;
-	fpga_count = 0;
-	return false;
+        if (this->stream_end_requested) {
+            // end_stream() was called before first packet was received
+            pthread_mutex_unlock(&this->state_lock);
+            nupfreq = 0;
+            nt_per_packet = 0;
+            fpga_counts_per_sample = 0;
+            fpga_count = 0;
+            return false;
+        }
     }
     
     pthread_mutex_unlock(&this->state_lock);
@@ -421,7 +422,7 @@ void intensity_network_stream::_network_thread_body()
 {
     pthread_mutex_lock(&this->state_lock);
 
-    // ...and wait for it to advance to "stream_started"
+    // Wait for "stream_started"
     for (;;) {
 	if (this->stream_end_requested) {
 	    // This case can arise if end_stream() is called early

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -321,6 +321,11 @@ intensity_network_stream::get_statistics() {
     m["count_assembler_drops"    ] = counts[event_type::assembled_chunk_dropped];
     m["count_assembler_queued"   ] = counts[event_type::assembled_chunk_queued];
 
+    int currsize, maxsize;
+    unassembled_ringbuf->get_size(&currsize, &maxsize);
+    m["udp_ringbuf_size"] = currsize;
+    m["udp_ringbuf_maxsize"] = maxsize;
+
     int nbeams = this->ini_params.beam_ids.size();
     m["nbeams"] = nbeams;
     R.push_back(m);

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -530,13 +530,13 @@ void intensity_network_stream::_network_thread_body()
             throw runtime_error(string("ch_frb_io network thread: read() failed: ") + strerror(errno));
 	}
 
-        /*{
+        {
             int nqueued = 0;
             if (ioctl(sockfd, FIONREAD, &nqueued) == -1) {
                 cout << "Failed to call ioctl(FIONREAD)" << endl;
             }
             cout << "recv: now " << nqueued << " bytes queued in UDP socket" << endl;
-         }*/
+        }
 
         // Increment the number of packets we've received from this sender:
         uint64_t ip = ntohl(sender_addr.sin_addr.s_addr);

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -367,12 +367,12 @@ intensity_network_stream::get_statistics() {
     return R;
 }
 
-vector< vector< shared_ptr<assembled_chunk> > >
+vector< vector< pair<shared_ptr<assembled_chunk>, uint64_t> > >
 intensity_network_stream::get_ringbuf_snapshots(vector<uint64_t> &beams,
                                                 uint64_t min_fpga_counts,
                                                 uint64_t max_fpga_counts)
 {
-    vector< vector< shared_ptr<assembled_chunk> > > R;
+    vector< vector< pair<shared_ptr<assembled_chunk>, uint64_t> > > R;
 
     pthread_mutex_lock(&this->state_lock);
     bool assemblers_init = this->assemblers_initialized;
@@ -385,7 +385,7 @@ intensity_network_stream::get_ringbuf_snapshots(vector<uint64_t> &beams,
 
     for (size_t ib=0; ib<beams.size(); ib++) {
         uint64_t beam = beams[ib];
-        vector<shared_ptr<assembled_chunk> > chunks;
+        vector<pair<shared_ptr<assembled_chunk>, uint64_t > > chunks;
         // Which of my assemblers (if any) is handling the requested beam?
         for (int i=0; i<nbeams; i++) {
 	    if (this->ini_params.beam_ids[i] != (int)beam)

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -421,10 +421,6 @@ void intensity_network_stream::_network_thread_body()
 {
     pthread_mutex_lock(&this->state_lock);
 
-    // Advance stream state to "network_thread_started"...
-    this->network_thread_started = true;
-    pthread_cond_broadcast(&this->cond_state_changed);
-
     // ...and wait for it to advance to "stream_started"
     for (;;) {
 	if (this->stream_end_requested) {
@@ -645,12 +641,8 @@ void intensity_network_stream::assembler_thread_main() {
 
 void intensity_network_stream::_assembler_thread_body()
 {
-    // Set the assembler_thread_started flag...
     pthread_mutex_lock(&this->state_lock);
-    this->assembler_thread_started = true;
-    pthread_cond_broadcast(&this->cond_state_changed);
-
-    // ... and wait for first_packet_received flag to be set
+    // wait for first_packet_received flag to be set
     for (;;) {
    	if (this->stream_end_requested) {
 	    // This case can arise if end_stream() is called early

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -226,6 +226,14 @@ void intensity_network_stream::stream_to_files(const std::string& filename_patte
             (*it)->stream_filename_pattern = filename_pattern;
 }
 
+void intensity_network_stream::print_state() {
+    cout << "Intensity network stream state:" << endl;
+    for (auto it = assemblers.begin(); it != assemblers.end(); it++) {
+        cout << "--Assembler:" << endl;
+        (*it)->print_state();
+    }
+}
+
 // Must not hold state_lock when calling this function!
 void intensity_network_stream::_wait_for_assemblers_initialized(bool prelocked) {
     // wait for assemblers to be initialized...

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -326,6 +326,8 @@ intensity_network_stream::get_statistics() {
     m["udp_ringbuf_size"] = currsize;
     m["udp_ringbuf_maxsize"] = maxsize;
 
+    m["count_bytes_queued"] = socket_queued_bytes;
+
     int nbeams = this->ini_params.beam_ids.size();
     m["nbeams"] = nbeams;
     R.push_back(m);
@@ -535,7 +537,8 @@ void intensity_network_stream::_network_thread_body()
             if (ioctl(sockfd, FIONREAD, &nqueued) == -1) {
                 cout << "Failed to call ioctl(FIONREAD)" << endl;
             }
-            cout << "recv: now " << nqueued << " bytes queued in UDP socket" << endl;
+            socket_queued_bytes = nqueued;
+            //cout << "recv: now " << nqueued << " bytes queued in UDP socket" << endl;
         }
 
         // Increment the number of packets we've received from this sender:

--- a/l1-ringbuf.cpp
+++ b/l1-ringbuf.cpp
@@ -153,16 +153,16 @@ void L1Ringbuf::print() {
     for (auto it = _q.begin(); it != _q.end(); it++) {
         cout << (*it)->ichunk << " ";
     }
-    cout << "];" << endl;
+    cout << "]" << endl;
     for (size_t i=0; i<_nbins; i++) {
         vector<shared_ptr<assembled_chunk> > v = _rb[i]->snapshot(NULL);
-        cout << "  binning " << i << ": [ ";
+        cout << "  binning " << i << ":  [ ";
         for (auto it = v.begin(); it != v.end(); it++) {
             cout << (*it)->ichunk << " ";
         }
         cout << "]" << endl;
         if (i < _nbins-1) {
-            cout << "  dropped " << i << ": ";
+            cout << "  dropped " << i << ":  ";
             if (_dropped[i])
                 cout << _dropped[i]->ichunk << endl;
             else

--- a/l1-ringbuf.cpp
+++ b/l1-ringbuf.cpp
@@ -68,8 +68,8 @@ L1Ringbuf::L1Ringbuf(uint64_t beam_id, vector<int> ringbuf_n) :
 }
 
 /*
- Tries to enqueue an assembled_chunk.  If no space can be
- allocated, returns false.  The ring buffer now assumes ownership
+ Tries to enqueue an assembled_chunk.  If no space can be allocated,
+ returns an empty shared_ptr.  The ring buffer now assumes ownership
  of the assembled_chunk.
  */
 shared_ptr<assembled_chunk> L1Ringbuf::push(assembled_chunk* ch) {

--- a/l1-ringbuf.cpp
+++ b/l1-ringbuf.cpp
@@ -49,14 +49,13 @@ L1Ringbuf::L1Ringbuf(uint64_t beam_id, vector<int> ringbuf_n) :
     _rb(),
     _dropped()
 {
-    if (ringbuf_n.size() == 0) {
-        // ringbuffer sizes per binning level -- if specified,
-        // overrides the number of levels and their sizes.  Otherwise,
-        // take defaults
-        for (int i=0; i<constants::assembled_ringbuf_nlevels; i++)
-            ringbuf_n.push_back(constants::assembled_ringbuf_capacity);
-    }
     _nbins = ringbuf_n.size();
+    
+    // We should never get an empty vector here, since the intensity_network_stream
+    // constructor now contains logic to replace an empty vector by a sensible default.
+    if (_nbins == 0)
+	throw runtime_error("ch_frb_io: internal error: empty ringbuf_n vector in L1Ringbuf constructor");
+
     // Create the ring buffer objects for each time binning
     // (0 = native rate, 1 = binned by 2, ...)
     for (size_t i=0; i<_nbins; i++)

--- a/l1-ringbuf.cpp
+++ b/l1-ringbuf.cpp
@@ -72,12 +72,12 @@ L1Ringbuf::L1Ringbuf(uint64_t beam_id, vector<int> ringbuf_n) :
  allocated, returns false.  The ring buffer now assumes ownership
  of the assembled_chunk.
  */
-bool L1Ringbuf::push(assembled_chunk* ch) {
+shared_ptr<assembled_chunk> L1Ringbuf::push(assembled_chunk* ch) {
     shared_ptr<assembled_chunk> p = _rb[0]->push(ch);
     if (!p)
-        return false;
+        return p;
     _q.push_back(p);
-    return true;
+    return p;
 }
 
 /*

--- a/l1-ringbuf.hpp
+++ b/l1-ringbuf.hpp
@@ -53,10 +53,10 @@ public:
 
     /*
      Tries to enqueue an assembled_chunk.  If no space can be
-     allocated, returns false.  The ring buffer now assumes ownership
-     of the assembled_chunk.
+     allocated, returns an empty shared_ptr.  The ring buffer now
+     assumes ownership of the assembled_chunk.
      */
-    bool push(ch_frb_io::assembled_chunk* ch);
+    std::shared_ptr<ch_frb_io::assembled_chunk> push(ch_frb_io::assembled_chunk* ch);
 
     /*
      Returns the next assembled_chunk for downstream processing.

--- a/l1-ringbuf.hpp
+++ b/l1-ringbuf.hpp
@@ -42,7 +42,9 @@ enum l1_ringbuf_level {
     L1RB_LEVEL4 = 0x10,
     L1RB_WAIT1 = 0x20,
     L1RB_WAIT2 = 0x40,
-    L1RB_WAIT3 = 0x80
+    L1RB_WAIT3 = 0x80,
+    // queued for writing in the L1 RPC system
+    L1RB_WRITEQUEUE = 0x100,
 };
 
 class L1Ringbuf {

--- a/l1-ringbuf.hpp
+++ b/l1-ringbuf.hpp
@@ -34,6 +34,17 @@ protected:
     virtual void dropping(std::shared_ptr<ch_frb_io::assembled_chunk> t);
 };
 
+enum l1_ringbuf_level {
+    L1RB_DOWNSTREAM = 1,
+    L1RB_LEVEL1 = 2,
+    L1RB_LEVEL2 = 4,
+    L1RB_LEVEL3 = 8,
+    L1RB_LEVEL4 = 0x10,
+    L1RB_WAIT1 = 0x20,
+    L1RB_WAIT2 = 0x40,
+    L1RB_WAIT3 = 0x80
+};
+
 class L1Ringbuf {
     friend class AssembledChunkRingbuf;
 
@@ -92,7 +103,7 @@ public:
      applied; likewise for max_fpga_counts.
      */
     void retrieve(uint64_t min_fpga_counts, uint64_t max_fpga_counts,
-                  std::vector<std::shared_ptr<ch_frb_io::assembled_chunk> >&chunks);
+                  std::vector<std::pair<std::shared_ptr<ch_frb_io::assembled_chunk>, uint64_t> > &chunks);
 
 public:
     uint64_t _beam_id;

--- a/misc.cpp
+++ b/misc.cpp
@@ -1,0 +1,39 @@
+#include <thread>
+#include "ch_frb_io.hpp"
+
+using namespace std;
+
+namespace ch_frb_io {
+#if 0
+};  // pacify emacs c-mode!
+#endif
+
+
+void pin_thread_to_cores(const vector<int> &core_list)
+{
+    if (core_list.size() == 0)
+	return;
+
+#ifdef __APPLE__
+    cerr << "warning: pinning threads to cores is not implemented in osx\n";
+#else
+    int hwcores = std::thread::hardware_concurrency();
+    pthread_t thread = pthread_self();
+
+    cpu_set_t cs;
+    CPU_ZERO(&cs);
+
+    for (int core_id: core_list) {
+	if ((core_id < 0) || (core_id >= hwcores))
+	    throw runtime_error("pin_thread_to_cores: core_id=" + to_string(core_id) + " is out of range (hwcores=" + to_string(hwcores) + ")");
+	CPU_SET(core_id, &cs);
+    }
+
+    int err = pthread_setaffinity_np(thread, sizeof(cs), &cs);
+    if (err)
+        throw runtime_error("pthread_setaffinity_np() failed");
+#endif
+}
+
+
+}  // namespace ch_frb_io

--- a/site/Makefile.local.frb-compute-0
+++ b/site/Makefile.local.frb-compute-0
@@ -1,0 +1,42 @@
+# Makefile.local for frb1.physics.mcgill.ca
+
+# Directory where C++ libraries will be installed
+LIBDIR=$(HOME)/lib
+
+# Directory where C++ header files will be installed
+INCDIR=$(HOME)/include
+
+# Directory where executables will be installed
+BINDIR=$(HOME)/bin
+
+MSGPACK_INC_DIR ?= /usr/include
+
+ZMQ_INC_DIR ?= /usr/include
+ZMQ_LIB_DIR ?= /usr/lib64
+
+CXX ?= g++
+
+OPTIMIZE ?= yes
+ifeq ($(OPTIMIZE), yes)
+    OPT_FLAGS := -O3 -funroll-loops
+else
+    OPT_FLAGS := -O0 -g
+endif
+
+COVERAGE ?= no
+ifeq ($(COVERAGE), yes)
+    # Travis + Coverall: include coverage tracking code.  Also note that we turned off optimization!
+    OPT_FLAGS += -fprofile-arcs -ftest-coverage
+endif
+
+#
+# C++ command line
+# Must support c++11
+# Don't forget to put -L. and -L$(LIBDIR) on the command line (in this order)
+# Don't forget to add . and $(LIBDIR) in your LD_LIBRARY_PATH environment variable (in this order)
+# Don't forget -pthread and -fPIC
+#
+
+CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall $(OPT_FLAGS) -march=native -ffast-math -I. -I$(INCDIR) -I$(MSGPACK_INC_DIR) -I$(ZMQ_INC_DIR)
+
+CPP_LFLAGS := -L. -L$(LIBDIR) -L$(ZMQ_LIB_DIR)

--- a/udp_packet_ringbuf.cpp
+++ b/udp_packet_ringbuf.cpp
@@ -34,6 +34,14 @@ udp_packet_ringbuf::~udp_packet_ringbuf()
     pthread_cond_destroy(&cond_packets_removed);
 }
 
+void udp_packet_ringbuf::get_size(int* currsize, int* maxsize) {
+    pthread_mutex_lock(&this->lock);
+    if (currsize)
+        *currsize = ringbuf_size;
+    if (maxsize)
+        *maxsize = ringbuf_capacity;
+    pthread_mutex_unlock(&this->lock);
+}
 
 bool udp_packet_ringbuf::put_packet_list(unique_ptr<udp_packet_list> &p, bool is_blocking)
 {    


### PR DESCRIPTION
- when retrieving assembled_chunks from the ring buffer, return a bitmask of where in the ringbuffer the chunks were found (what level, etc)
- add debugging ability to inject chunks
- track time used in network & assembler threads
- use std::thread for network & assembler threads
