### PR TITLE
msgpack output: add a shared buffer for storing compressed data

### DIFF
--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -515,6 +515,10 @@ void assembled_chunk::write_msgpack_file(const string &filename)
         throw runtime_error("ch_frb_io: failed to rename temp file in writing assembled_chunk msgpack file: " + string(tempfilename) + ": " + string(strerror(errno)));
 }
 
+size_t assembled_chunk::max_compressed_size() {
+    return bshuf_compress_lz4_bound(this->ndata, 1, 0);
+}
+
 shared_ptr<assembled_chunk> assembled_chunk::read_msgpack_file(const string &filename)
 {
     struct stat st;

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -120,12 +120,12 @@ struct pack<std::shared_ptr<ch_frb_io::assembled_chunk> > {
         bool compress = ch->msgpack_bitshuffle;
         size_t maxsize;
         if (compress) {
+            compression = (uint8_t)comp_bitshuffle;
             if (ch->compression_buffer) {
                 // We can use this shared buffer for compression
                 data = ch->compression_buffer;
             } else {
                 // Try to allocate a temp buffer for the compressed data.
-                compression = (uint8_t)comp_bitshuffle;
                 // How big can the compressed data become?
                 maxsize = ch->max_compressed_size();
                 std::cout << "bitshuffle: uncompressed size " << ch->ndata << ", max compressed size " << maxsize << std::endl;

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -14,17 +14,101 @@ extern "C" {
 
 #include <ch_frb_io.hpp>
 
-
 /** Code for packing objects into msgpack mesages, and vice versa. **/
+
+enum compression_type {
+    comp_none = 0,
+    comp_bitshuffle = 1
+};
+
+// Our own function for packing an assembled_chunk into a msgpack stream,
+// including an optional buffer for compression.
+template <typename Stream>
+void pack_assembled_chunk(msgpack::packer<Stream>& o,
+                          std::shared_ptr<ch_frb_io::assembled_chunk> const& ch,
+                          bool compress=false,
+                          uint8_t* buffer=NULL) {
+    // pack member variables as an array.
+    //std::cout << "Pack shared_ptr<assembled-chunk> into msgpack object..." << std::endl;
+    uint8_t version = 1;
+    // We are going to pack 17 items as a msgpack array (with mixed types)
+    o.pack_array(17);
+    // Item 0: header string
+    o.pack("assembled_chunk in msgpack format");
+    // Item 1: version number
+    o.pack(version);
+
+    uint8_t compression = (uint8_t)comp_none;
+    int data_size = ch->ndata;
+
+    // Create a shared pointer to the block of data to be written
+    // (which defaults to this assembled_chunk's data, which is not to be deleted)
+    std::shared_ptr<uint8_t> chdata(std::shared_ptr<uint8_t>(), ch->data);
+    std::shared_ptr<uint8_t> data = chdata;
+    if (compress) {
+        compression = (uint8_t)comp_bitshuffle;
+        if (buffer) {
+            // We can use this buffer for compression
+            data = std::shared_ptr<uint8_t>(std::shared_ptr<uint8_t>(), buffer);
+        } else {
+            // Try to allocate a temp buffer for the compressed data.
+            // How big can the compressed data become?
+            size_t maxsize = ch->max_compressed_size();
+            std::cout << "bitshuffle: uncompressed size " << ch->ndata << ", max compressed size " << maxsize << std::endl;
+            data = std::shared_ptr<uint8_t>((uint8_t*)malloc(maxsize));
+            // unlikely...
+            if (!data) {
+                std::cout << "Failed to allocate a buffer to compress an assembled_chunk; writing uncompressed" << std::endl;
+                compression = (uint8_t)comp_none;
+                data = chdata;
+                compress = false;
+            }
+        }
+    }
+    if (compress) {
+        // Try compressing.  If the compressed size is not smaller than the original, write uncompressed instead.
+        int64_t n = bshuf_compress_lz4(ch->data, data.get(), ch->ndata, 1, 0);
+        if ((n < 0) || (n >= ch->ndata)) {
+            if (n < 0)
+                std::cout << "bitshuffle compression failed; writing uncompressed" << std::endl;
+            else
+                std::cout << "bitshuffle compression did not actually compress the data (" + std::to_string(n) + " vs orig " + std::to_string(ch->ndata) + "); writing uncompressed" << std::endl;
+            data = chdata;
+            compression = (uint8_t)comp_none;
+            compress = false;
+        } else {
+            data_size = n;
+            std::cout << "Bitshuffle compressed to " << n << std::endl;
+        }
+    }
+    o.pack(compression);
+    o.pack(data_size);
+
+    o.pack(ch->beam_id);
+    o.pack(ch->nupfreq);
+    o.pack(ch->nt_per_packet);
+    o.pack(ch->fpga_counts_per_sample);
+    o.pack(ch->nt_coarse);
+    o.pack(ch->nscales);
+    o.pack(ch->ndata);
+    o.pack(ch->fpga_begin);
+    o.pack(ch->fpga_end - ch->fpga_begin);
+    o.pack(ch->binning);
+    // PACK FLOATS AS BINARY
+    int nscalebytes = ch->nscales * sizeof(float);
+    o.pack_bin(nscalebytes);
+    o.pack_bin_body(reinterpret_cast<const char*>(ch->scales),
+                    nscalebytes);
+    o.pack_bin(nscalebytes);
+    o.pack_bin_body(reinterpret_cast<const char*>(ch->offsets),
+                    nscalebytes);
+    o.pack_bin(data_size);
+    o.pack_bin_body(reinterpret_cast<const char*>(data.get()), data_size);
+}
 
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
 namespace adaptor {
-
-    enum compression_type {
-        comp_none = 0,
-        comp_bitshuffle = 1
-    };
 
   // Unpack a msgpack object into an assembled_chunk.
 template<>
@@ -111,84 +195,7 @@ template<>
 struct pack<std::shared_ptr<ch_frb_io::assembled_chunk> > {
     template <typename Stream>
     packer<Stream>& operator()(msgpack::packer<Stream>& o, std::shared_ptr<ch_frb_io::assembled_chunk>  const& ch) const {
-        // packing member variables as an array.
-        //std::cout << "Pack shared_ptr<assembled-chunk> into msgpack object..." << std::endl;
-        uint8_t version = 1;
-        // We are going to pack 17 items as a msgpack array (with mixed types)
-        o.pack_array(17);
-        // Item 0: header string
-        o.pack("assembled_chunk in msgpack format");
-        // Item 1: version number
-        o.pack(version);
-
-        uint8_t compression = (uint8_t)comp_none;
-        int data_size = ch->ndata;
-
-        // Create a shared pointer to the block of data to be written
-        // (which defaults to this assembled_chunk's data, which is not to be deleted)
-        std::shared_ptr<uint8_t> chdata(std::shared_ptr<uint8_t>(), ch->data);
-        std::shared_ptr<uint8_t> data = chdata;
-        bool compress = ch->msgpack_bitshuffle;
-        size_t maxsize;
-        if (compress) {
-            compression = (uint8_t)comp_bitshuffle;
-            if (ch->compression_buffer) {
-                // We can use this shared buffer for compression
-                data = ch->compression_buffer;
-            } else {
-                // Try to allocate a temp buffer for the compressed data.
-                // How big can the compressed data become?
-                maxsize = ch->max_compressed_size();
-                std::cout << "bitshuffle: uncompressed size " << ch->ndata << ", max compressed size " << maxsize << std::endl;
-                data = std::shared_ptr<uint8_t>((uint8_t*)malloc(maxsize));
-                // unlikely...
-                if (!data) {
-                    std::cout << "Failed to allocate a buffer to compress an assembled_chunk; writing uncompressed" << std::endl;
-                    compression = (uint8_t)comp_none;
-                    data = chdata;
-                    compress = false;
-                }
-            }
-        }
-        if (compress) {
-            // Try compressing.  If the compressed size is not smaller than the original, write uncompressed instead.
-            int64_t n = bshuf_compress_lz4(ch->data, data.get(), ch->ndata, 1, 0);
-            if ((n < 0) || (n >= ch->ndata)) {
-                if (n < 0)
-                    std::cout << "bitshuffle compression failed; writing uncompressed" << std::endl;
-                else
-                    std::cout << "bitshuffle compression did not actually compress the data (" + std::to_string(n) + " vs orig " + std::to_string(ch->ndata) + "); writing uncompressed" << std::endl;
-                data = chdata;
-                compression = (uint8_t)comp_none;
-                compress = false;
-            } else {
-                data_size = n;
-                std::cout << "Bitshuffle compressed to " << n << std::endl;
-            }
-        }
-        o.pack(compression);
-        o.pack(data_size);
-
-        o.pack(ch->beam_id);
-        o.pack(ch->nupfreq);
-        o.pack(ch->nt_per_packet);
-        o.pack(ch->fpga_counts_per_sample);
-        o.pack(ch->nt_coarse);
-        o.pack(ch->nscales);
-        o.pack(ch->ndata);
-        o.pack(ch->fpga_begin);
-        o.pack(ch->fpga_end - ch->fpga_begin);
-        o.pack(ch->binning);
-        // PACK FLOATS AS BINARY
-        int nscalebytes = ch->nscales * sizeof(float);
-        o.pack_bin(nscalebytes);
-        o.pack_bin_body(reinterpret_cast<const char*>(ch->scales),
-                        nscalebytes);
-        o.pack_bin(nscalebytes);
-        o.pack_bin_body(reinterpret_cast<const char*>(ch->offsets),
-                        nscalebytes);
-        o.pack_bin(data_size);
-        o.pack_bin_body(reinterpret_cast<const char*>(data.get()), data_size);
+        pack_assembled_chunk(o, ch);
         return o;
     }
 };

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -302,10 +302,7 @@ bool assembled_chunk_ringbuf::_put_assembled_chunk(unique_ptr<assembled_chunk> &
     if (stream_filename_pattern.length()) {
         string fn = pushlist[0]->format_filename(stream_filename_pattern);
         // turn on compression, but revert the state of pushlist[0]->msgpack_bitshuffle after writing.
-        bool bitpack = pushlist[0]->msgpack_bitshuffle;
-        pushlist[0]->msgpack_bitshuffle = true;
-        pushlist[0]->write_msgpack_file(fn);
-        pushlist[0]->msgpack_bitshuffle = bitpack;
+        pushlist[0]->write_msgpack_file(fn, true);
     }
 
     for (auto it=chunk_callbacks.begin(); it!=chunk_callbacks.end(); it++) {

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -566,8 +566,6 @@ public:
     const uint64_t fpga_begin = 0;    // equal to ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample
     const uint64_t fpga_end = 0;      // equal to (ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample
 
-    bool msgpack_bitshuffle = false;
-
     // Note: you probably don't want to call the assembled_chunk constructor directly!
     // Instead use the static factory function assembed_chunk::make().
     assembled_chunk(const initializer &ini_params);
@@ -589,15 +587,12 @@ public:
 
     // Note: the hdf5 file format has been phased out now..
     void write_hdf5_file(const std::string &filename);
-    void write_msgpack_file(const std::string &filename);
+    void write_msgpack_file(const std::string &filename, bool compress,
+                            uint8_t* buffer=NULL);
 
-    // A shared pointer to a buffer that can be used for temporary storage
-    // during msgpack compression.  There is no locking of this buffer, so it
-    // is responsibility of the user to ensure that assembled_chunks that
-    // share a buffer never try to use it simultaneously.
-    // Should be at least max_compressed_size().
-    std::shared_ptr<uint8_t> compression_buffer;
-    
+    // How big can the bitshuffle-compressed data for a chunk of this size become?
+    size_t max_compressed_size();
+
     // Performs a printf-like pattern replacement on *pattern* given the parameters of this assembled_chunk.
     // Replacements:
     //   (BEAM)    -> %04i beam_id
@@ -656,9 +651,6 @@ public:
     virtual void decode(float *intensity, float *weights, int stride) const override;
     virtual void downsample(const assembled_chunk *src1, const assembled_chunk *src2) override;
 
-    // How big can the bitshuffle-compressed data for a chunk of this size become?
-    size_t max_compressed_size();
-    
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -651,16 +651,14 @@ public:
     fast_assembled_chunk(const assembled_chunk::initializer &ini_params);
     virtual ~fast_assembled_chunk();
 
-<<<<<<< HEAD
     // Override viruals with fast assembly language versions.
     virtual void add_packet(const intensity_packet &p) override;
     virtual void decode(float *intensity, float *weights, int stride) const override;
     virtual void downsample(const assembled_chunk *src1, const assembled_chunk *src2) override;
-=======
-    // How big can the compressed data become?
+
+    // How big can the bitshuffle-compressed data for a chunk of this size become?
     size_t max_compressed_size();
     
->>>>>>> msgpack-nomalloc
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -563,6 +563,13 @@ struct assembled_chunk : noncopyable {
 
     bool msgpack_bitshuffle = false;
 
+    // A shared pointer to a buffer that can be used for temporary storage
+    // during msgpack compression.  There is no locking of this buffer, so it
+    // is responsibility of the user to ensure that assembled_chunks that
+    // share a buffer never try to use it simultaneously.
+    // Should be at least max_compressed_size().
+    std::shared_ptr<uint8_t> compression_buffer;
+    
     assembled_chunk(int beam_id, int nupfreq, int nt_per_packet, int fpga_counts_per_sample, uint64_t ichunk);
     virtual ~assembled_chunk();
 
@@ -617,6 +624,9 @@ struct assembled_chunk : noncopyable {
     // msgpack file output
     void write_msgpack_file(const std::string &filename);
 
+    // How big can the compressed data become?
+    size_t max_compressed_size();
+    
 };
 
 // For some choices of packet parameters (the precise criterion is nt_per_packet == 16 and

--- a/site/Makefile.local.travis
+++ b/site/Makefile.local.travis
@@ -9,8 +9,8 @@ INCDIR=$(HOME)/chime/include
 # Directory where executables will be installed
 BINDIR=$(HOME)/chime/bin
 
-# HDF5_INC_DIR=/usr/local/include
-# HDF5_LIB_DIR=/usr/local/lib
+HDF5_INC_DIR ?= /usr/local/include
+HDF5_LIB_DIR ?= /usr/local/lib
 
 MSGPACK_INC_DIR ?= /home/travis/build/CHIMEFRB/ch_frb_io/msgpack-2.1.0/include
 
@@ -39,6 +39,6 @@ ifeq ($(COVERAGE), yes)
     OPT_FLAGS += -fprofile-arcs -ftest-coverage
 endif
 
-CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall $(OPT_FLAGS) -march=native -ffast-math -I. -I$(INCDIR) -I$(MSGPACK_INC_DIR) -I$(ZMQ_INC_DIR)
+CPP := $(CXX) -std=c++11 -pthread -fPIC -Wall $(OPT_FLAGS) -march=native -ffast-math -I. -I$(INCDIR) -I$(MSGPACK_INC_DIR) -I$(ZMQ_INC_DIR) -I$(HDF5_INC_DIR)
 
-CPP_LFLAGS := -L. -L$(LIBDIR) -L$(ZMQ_LIB_DIR)
+CPP_LFLAGS := -L. -L$(LIBDIR) -L$(ZMQ_LIB_DIR) -L$(HDF5_LIB_DIR)

--- a/test-assembled-chunk.cpp
+++ b/test-assembled-chunk.cpp
@@ -62,6 +62,17 @@ int main(int argc, char **argv)
         cout << "MISMATCH in data 2" << endl;
     }
 
+    // Set the shared compression buffer and write compressed data.
+    chunk->compression_buffer = shared_ptr<uint8_t>((uint8_t*)malloc(chunk->max_compressed_size()));
+    chunk->msgpack_bitshuffle = true;
+    fn = "test_assembled_chunk_3.msgpack";
+    chunk->write_msgpack_file(fn);
+    cout << "Wrote to " << fn << endl;
+    
+    shared_ptr<assembled_chunk> inchunk3 = assembled_chunk::read_msgpack_file(fn);
+    if (memcmp(inchunk3->data, chunk->data, chunk->ndata)) {
+        cout << "MISMATCH in data 3" << endl;
+    }
 
     unique_ptr<assembled_chunk> uchunk2 = assembled_chunk::make(beam_id, nupfreq, nt_per_packet, fpga_counts_per_sample, ichunk+1);
 

--- a/test-assembled-chunk.cpp
+++ b/test-assembled-chunk.cpp
@@ -74,6 +74,11 @@ int main(int argc, char **argv)
         cout << "MISMATCH in data 3" << endl;
     }
 
+    // Just write again, testing the buffer...?
+    fn = "test_assembled_chunk_4.msgpack";
+    chunk->write_msgpack_file(fn);
+    cout << "Wrote to " << fn << endl;
+
     unique_ptr<assembled_chunk> uchunk2 = assembled_chunk::make(beam_id, nupfreq, nt_per_packet, fpga_counts_per_sample, ichunk+1);
 
     assembled_chunk* chunk2 = uchunk2.get();
@@ -114,7 +119,7 @@ int main(int argc, char **argv)
     chunk1->write_msgpack_file("test-chunk1.msgpack");
     chunk2->write_msgpack_file("test-chunk2.msgpack");
 
-    assembled_chunk* chunk3 = assembled_chunk::downsample(NULL, chunk1, chunk2);
+    shared_ptr<assembled_chunk> chunk3 = shared_ptr<assembled_chunk>(assembled_chunk::downsample(NULL, chunk1, chunk2));
     chunk3->write_msgpack_file("test-chunk3.msgpack");
 
     float* intensity = (float*)malloc(chunk1->ndata * sizeof(float));
@@ -137,5 +142,8 @@ int main(int argc, char **argv)
     fwrite(intensity, 1, chunk1->ndata * sizeof(float), f);
     fclose(f);
 
+    free(intensity);
+    free(weight);
+    
     return 0;
 }


### PR DESCRIPTION
* add to the assembled_chunk struct a shared_ptr to a buffer that can be used during compression
* detail: within assembled_chunk msgpack output, use shared_ptrs to simplify the buffer allocate/free logic; remove realloc() and explicit free()s
