### PR TITLE
improve get_ringbuf_snapshot() arguments

### DIFF
--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -388,9 +388,13 @@ public:
     // Retrieves chunks from one or more ring buffers.  The uint64_t
     // return value is a bitmask of l1_ringbuf_level values saying
     // where in the ringbuffer the chunk was found; this is an
-    // implementation detail revealed for debugging purposes
+    // implementation detail revealed for debugging purposes.
+    //
+    // If a vector of beam numbers is given, only the ring buffers for
+    // those beams will be returned; otherwise the ring buffers for
+    // all beams will be returned.
     std::vector< std::vector< std::pair<std::shared_ptr<assembled_chunk>, uint64_t> > >
-    get_ringbuf_snapshots(std::vector<uint64_t> &beams,
+    get_ringbuf_snapshots(const std::vector<int> &beams = std::vector<int>(),
                           uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 
     // For debugging/testing purposes: pretend that the given

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -109,6 +109,8 @@ void output_device::io_thread_main()
 	    chlog(error_message);
 	else if (ini_params.verbosity >= 3)
 	    chlog("wrote " + w->filename);
+
+        w->write_callback(error_message);
     }
 
     if (ini_params.verbosity >= 2)

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -71,7 +71,7 @@ void output_device::io_thread_main()
 		chlog("write request '" + w->filename + "' is a duplicate, skipping...");
 
 	    w->write_callback("");
-	    return;
+            continue;
 	}
 	
 	// If this write request is a "pseudo-duplicate", i.e. the same chunk has been


### PR DESCRIPTION
* make get_ringbuf_snapshot() take a const vector<int> of beam ids, not a vector<uint64_t>
* add default list of beams and return all beams if not specified
