### PR TITLE
Define a memory slab type to ensure that memory allocated with malloc() is freed with free()

### DIFF
--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -102,8 +102,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     ndata(constants::nfreq_coarse_tot * nupfreq * constants::nt_per_assembled_chunk),
     isample(ichunk * constants::nt_per_assembled_chunk),
     fpga_begin(ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
-    fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
-    memory_slab(NULL, &std::free)
+    fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample)
 {
     if ((beam_id < 0) || (beam_id > constants::max_allowed_beam_id))
 	throw runtime_error("assembled_chunk constructor: bad 'beam_id' argument");
@@ -143,7 +142,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
 	    throw runtime_error("assembled_chunk constructor: 'pool' is an empty pointer, but 'slab' is nonempty");
 
 	uint8_t *p = aligned_alloc<uint8_t> (mc.slab_size);
-	this->memory_slab = memory_slab_t(p, &std::free);
+	this->memory_slab = memory_slab_t(p);
     }
 
     this->data = memory_slab.get() + mc.ib_data;

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -102,7 +102,8 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     ndata(constants::nfreq_coarse_tot * nupfreq * constants::nt_per_assembled_chunk),
     isample(ichunk * constants::nt_per_assembled_chunk),
     fpga_begin(ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
-    fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample)
+    fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
+    memory_slab(NULL, &std::free)
 {
     if ((beam_id < 0) || (beam_id > constants::max_allowed_beam_id))
 	throw runtime_error("assembled_chunk constructor: bad 'beam_id' argument");
@@ -142,7 +143,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
 	    throw runtime_error("assembled_chunk constructor: 'pool' is an empty pointer, but 'slab' is nonempty");
 
 	uint8_t *p = aligned_alloc<uint8_t> (mc.slab_size);
-	this->memory_slab = unique_ptr<uint8_t[]> (p);
+	this->memory_slab = memory_slab_t(p, &std::free);
     }
 
     this->data = memory_slab.get() + mc.ib_data;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -50,6 +50,8 @@ struct udp_packet_list;
 struct udp_packet_ringbuf;
 class assembled_chunk_ringbuf;
 
+typedef std::unique_ptr<uint8_t[], decltype(&std::free) > memory_slab_t;
+//typedef std::unique_ptr<uint8_t[], void(*)(void *)> memory_slab_t;
 
 // -------------------------------------------------------------------------------------------------
 //
@@ -702,7 +704,7 @@ public:
 protected:
     // The array members above (scales, ..., ds_mask) are packed into a single contiguous memory slab.
     std::shared_ptr<memory_slab_pool> memory_pool;
-    std::unique_ptr<uint8_t[]> memory_slab;
+    memory_slab_t memory_slab;
 
     void _check_downsample(const assembled_chunk *src1, const assembled_chunk *src2);
 
@@ -754,11 +756,11 @@ public:
     //
     // If zero=true, then the new slab is zeroed.
 
-    std::unique_ptr<uint8_t[]> get_slab(bool zero=true, bool wait=false);
+    memory_slab_t get_slab(bool zero=true, bool wait=false);
     
     // Puts a slab back in the pool.
     // Note: 'p' will be set to a null pointer after put_slab() returns.
-    void put_slab(std::unique_ptr<uint8_t[]> &p);
+    void put_slab(memory_slab_t &p);
 
     const ssize_t nbytes_per_slab;
     const ssize_t nslabs;
@@ -768,7 +770,7 @@ protected:
     std::mutex lock;
     std::condition_variable cv;
 
-    std::vector<std::unique_ptr<uint8_t[]>> slabs;
+    std::vector<memory_slab_t> slabs;
     ssize_t curr_size = 0;
     ssize_t low_water_mark = 0;
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -620,7 +620,7 @@ public:
 	// If a memory slab has been preallocated from a pool, these pointers should be set.
 	// Otherwise, both pointers should be empty, and the assembled_chunk constructor will allocate.
 	std::shared_ptr<memory_slab_pool> pool;
-	mutable std::unique_ptr<uint8_t[]> slab;
+        mutable memory_slab_t slab = memory_slab_t(NULL, &std::free);
     };
 
     // Parameters specified at construction.

--- a/memory_slab_pool.cpp
+++ b/memory_slab_pool.cpp
@@ -52,7 +52,7 @@ memory_slab_pool::~memory_slab_pool()
 memory_slab_t memory_slab_pool::get_slab(bool zero, bool wait)
 {
     ssize_t loc_size = 0;
-    memory_slab_t ret(NULL, &std::free);
+    memory_slab_t ret;
     unique_lock<std::mutex> ulock(this->lock);
 
     for (;;) {
@@ -118,7 +118,7 @@ void memory_slab_pool::allocate(const vector<int> &allocation_cores)
 
     for (ssize_t i = 0; i < nslabs; i++) {
 	uint8_t *p = aligned_alloc<uint8_t> (nbytes_per_slab);
-	this->slabs.push_back(memory_slab_t(p, &std::free));
+	this->slabs.push_back(memory_slab_t(p));
     }
 
     this->curr_size = nslabs;

--- a/memory_slab_pool.cpp
+++ b/memory_slab_pool.cpp
@@ -49,10 +49,10 @@ memory_slab_pool::~memory_slab_pool()
 }
 
 
-unique_ptr<uint8_t[]> memory_slab_pool::get_slab(bool zero, bool wait)
+memory_slab_t memory_slab_pool::get_slab(bool zero, bool wait)
 {
     ssize_t loc_size = 0;
-    unique_ptr<uint8_t[]> ret;
+    memory_slab_t ret(NULL, &std::free);
     unique_lock<std::mutex> ulock(this->lock);
 
     for (;;) {
@@ -86,7 +86,7 @@ unique_ptr<uint8_t[]> memory_slab_pool::get_slab(bool zero, bool wait)
 }
 
 
-void memory_slab_pool::put_slab(unique_ptr<uint8_t[]> &p)
+void memory_slab_pool::put_slab(memory_slab_t &p)
 {
     if (!p)
 	throw runtime_error("ch_frb_io: internal error: unexpected null pointer 'p' in memory_slab_pool::put_slab()");
@@ -114,11 +114,11 @@ void memory_slab_pool::allocate(const vector<int> &allocation_cores)
 {
     pin_thread_to_cores(allocation_cores);
 
-    this->slabs.resize(nslabs);
+    this->slabs.reserve(nslabs);
 
     for (ssize_t i = 0; i < nslabs; i++) {
 	uint8_t *p = aligned_alloc<uint8_t> (nbytes_per_slab);
-	this->slabs[i] = unique_ptr<uint8_t[]> (p);
+	this->slabs.push_back(memory_slab_t(p, &std::free));
     }
 
     this->curr_size = nslabs;


### PR DESCRIPTION
valgrind turned up an issue that the default unique_ptr deleter was using delete[] on memory that was allocated using malloc()-like aligned_alloc().  This defines a memory_slab_t with a custom deleter to ensure that free() is called.
