### PR TITLE
Propagate frame0 time

### DIFF
--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -546,6 +546,7 @@ void assembled_chunk::write_msgpack_file(const string &filename, bool compress, 
     // Construct a shared_ptr from this, carefully
     shared_ptr<assembled_chunk> shthis(shared_ptr<assembled_chunk>(), this);
     msgpack::packer<msgpack::fbuffer> packer(fb);
+    // The real deal: in assembled_chunk_msgpack.hpp
     pack_assembled_chunk(packer, shthis, compress, buffer);
 
     if (fclose(f))

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -97,6 +97,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     binning(ini_params.binning),
     stream_id(ini_params.stream_id),
     ichunk(ini_params.ichunk),
+    frame0_nano(ini_params.frame0_nano),
     nt_coarse(_nt_c(nt_per_packet)),
     nscales(constants::nfreq_coarse_tot * nt_coarse),
     ndata(constants::nfreq_coarse_tot * nupfreq * constants::nt_per_assembled_chunk),
@@ -193,6 +194,15 @@ ssize_t assembled_chunk::get_memory_slab_size(int nupfreq, int nt_per_packet)
 
 // -------------------------------------------------------------------------------------------------
 
+// Nanoseconds per FPGA count
+static const uint64_t fpga_nano = 2560;
+
+double assembled_chunk::time_begin() const {
+    return (frame0_nano + fpga_counts_per_sample * fpga_nano * fpga_begin) * 1e-9;
+}
+
+double assembled_chunk::time_end() const {
+    return (frame0_nano + fpga_counts_per_sample * fpga_nano * fpga_end) * 1e-9;}
 
 static string 
 __attribute__ ((format(printf,1,2)))

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -629,6 +629,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
     chunk_params.nupfreq = this->ini_params.nupfreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
+    chunk_params.frame0_nano = this->ini_params.frame0_nano;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;
     chunk_params.force_fast = this->ini_params.force_fast_kernels;
     chunk_params.stream_id = this->stream_id;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -639,6 +639,9 @@ public:
 	bool force_reference = false;
 	bool force_fast = false;
 
+        // "ctime" in nanoseconds of FGPAcount zero
+        uint64_t frame0_nano = 0;
+
 	// If a memory slab has been preallocated from a pool, these pointers should be set.
 	// Otherwise, both pointers should be empty, and the assembled_chunk constructor will allocate.
 	std::shared_ptr<memory_slab_pool> pool;
@@ -653,7 +656,10 @@ public:
     const int binning = 0;                   // either 1, 2, 4, 8... depending on level in telescoping ring buffer
     const int stream_id = 0;
     const uint64_t ichunk = 0;
-    
+
+    // "ctime" in nanoseconds of FGPAcount zero
+    uint64_t frame0_nano = 0;
+
     // Derived parameters.
     const int nt_coarse = 0;          // equal to (constants::nt_per_assembled_chunk / nt_per_packet)
     const int nscales = 0;            // equal to (constants::nfreq_coarse * nt_coarse)
@@ -666,6 +672,10 @@ public:
     // Instead use the static factory function assembed_chunk::make().
     assembled_chunk(const initializer &ini_params);
     virtual ~assembled_chunk();
+
+    // Returns C time() (seconds since the epoch, 1970.0) of the first/last sample in this chunk.
+    double time_begin() const;
+    double time_end() const;
 
     // The following virtual member functions have default implementations,
     // which are overridden by the subclass 'fast_assembled_chunk' to be faster

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -326,6 +326,8 @@ public:
 	int fpga_counts_per_sample = 384;
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
 
+        uint64_t frame0_nano = 0; // nanosecond time() value for fgpacount zero.
+        
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
 	std::string ipaddr = "0.0.0.0";
 	int udp_port = constants::default_udp_port;


### PR DESCRIPTION
This copies around the frame0 time (FPGA counts to time offset), from the intensity_network_stream into the assembled_chunk, and from there into the msgpack files.

This goes with https://github.com/kmsmith137/rf_pipelines/pull/22
and a ch_frb_l1 PR.
