### PR TITLE
Get frame0 ctime, part2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 ####################################################################################################
 
 
-LIBS = -lhdf5 -llz4 -lzmq
+LIBS = -lhdf5 -llz4 -lzmq -ljsoncpp -lcurl
 
 OFILES = assembled_chunk.o \
 	assembled_chunk_ringbuf.o \
@@ -106,10 +106,10 @@ test-intensity-hdf5-file: test-intensity-hdf5-file.cpp $(INCFILES) libch_frb_io.
 	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io
 
 test-assembled-chunk: test-assembled-chunk.cpp $(INCFILES) $(OFILES)
-	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) -llz4 -lhdf5 -lzmq
+	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) $(LIBS)
 
 test-weakptr: test-weakptr.cpp $(INCFILES) $(OFILES)
-	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) -llz4 -lhdf5 -lzmq
+	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) $(LIBS)
 
 test-misc: test-misc.cpp $(INCFILES) libch_frb_io.so
 	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -546,6 +546,7 @@ void assembled_chunk::write_msgpack_file(const string &filename, bool compress, 
     // Construct a shared_ptr from this, carefully
     shared_ptr<assembled_chunk> shthis(shared_ptr<assembled_chunk>(), this);
     msgpack::packer<msgpack::fbuffer> packer(fb);
+    // The real deal: in assembled_chunk_msgpack.hpp
     pack_assembled_chunk(packer, shthis, compress, buffer);
 
     if (fclose(f))

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -97,6 +97,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     binning(ini_params.binning),
     stream_id(ini_params.stream_id),
     ichunk(ini_params.ichunk),
+    frame0_nano(ini_params.frame0_nano),
     nt_coarse(_nt_c(nt_per_packet)),
     nscales(constants::nfreq_coarse_tot * nt_coarse),
     ndata(constants::nfreq_coarse_tot * nupfreq * constants::nt_per_assembled_chunk),
@@ -193,6 +194,15 @@ ssize_t assembled_chunk::get_memory_slab_size(int nupfreq, int nt_per_packet)
 
 // -------------------------------------------------------------------------------------------------
 
+// Nanoseconds per FPGA count
+static const uint64_t fpga_nano = 2560;
+
+double assembled_chunk::time_begin() const {
+    return (frame0_nano + fpga_counts_per_sample * fpga_nano * fpga_begin) * 1e-9;
+}
+
+double assembled_chunk::time_end() const {
+    return (frame0_nano + fpga_counts_per_sample * fpga_nano * fpga_end) * 1e-9;}
 
 static string 
 __attribute__ ((format(printf,1,2)))

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -629,6 +629,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
     chunk_params.nupfreq = this->ini_params.nupfreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
+    chunk_params.frame0_nano = this->ini_params.frame0_nano;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;
     chunk_params.force_fast = this->ini_params.force_fast_kernels;
     chunk_params.stream_id = this->stream_id;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -14,6 +14,7 @@ assembled_chunk_ringbuf::assembled_chunk_ringbuf(const intensity_network_stream:
     ini_params(ini_params_),
     beam_id(beam_id_),
     stream_id(stream_id_),
+    frame0_nano(ini_params_.frame0_nano),
     output_devices(ini_params.output_devices)
 {
     if ((beam_id < 0) || (beam_id > constants::max_allowed_beam_id))
@@ -63,6 +64,10 @@ assembled_chunk_ringbuf::~assembled_chunk_ringbuf()
     pthread_mutex_destroy(&this->lock);
 }
 
+
+void assembled_chunk_ringbuf::set_frame0(uint64_t f0) {
+    frame0_nano = f0;
+}
 
 void assembled_chunk_ringbuf::print_state() 
 {
@@ -629,7 +634,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
     chunk_params.nupfreq = this->ini_params.nupfreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
-    chunk_params.frame0_nano = this->ini_params.frame0_nano;
+    chunk_params.frame0_nano = this->frame0_nano;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;
     chunk_params.force_fast = this->ini_params.force_fast_kernels;
     chunk_params.stream_id = this->stream_id;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -327,6 +327,7 @@ public:
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
 
         uint64_t frame0_nano = 0; // nanosecond time() value for fgpacount zero.
+        std::string frame0_url = "";
         
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
 	std::string ipaddr = "0.0.0.0";
@@ -515,6 +516,8 @@ protected:
     std::atomic<uint64_t> assembler_thread_waiting_usec;
     std::atomic<uint64_t> assembler_thread_working_usec;
 
+    uint64_t frame0_nano;
+
     char _pad1b[constants::cache_line_size];
 
     // Used only by the network thread (not protected by lock)
@@ -587,6 +590,8 @@ protected:
     // Private methods called by the assembler thread.     
     void _assembler_thread_body();
     void _assembler_thread_exit();
+
+    bool _fetch_frame0();
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -639,6 +639,9 @@ public:
 	bool force_reference = false;
 	bool force_fast = false;
 
+        // "ctime" in nanoseconds of FGPAcount zero
+        uint64_t frame0_nano = 0;
+
 	// If a memory slab has been preallocated from a pool, these pointers should be set.
 	// Otherwise, both pointers should be empty, and the assembled_chunk constructor will allocate.
 	std::shared_ptr<memory_slab_pool> pool;
@@ -653,7 +656,10 @@ public:
     const int binning = 0;                   // either 1, 2, 4, 8... depending on level in telescoping ring buffer
     const int stream_id = 0;
     const uint64_t ichunk = 0;
-    
+
+    // "ctime" in nanoseconds of FGPAcount zero
+    uint64_t frame0_nano = 0;
+
     // Derived parameters.
     const int nt_coarse = 0;          // equal to (constants::nt_per_assembled_chunk / nt_per_packet)
     const int nscales = 0;            // equal to (constants::nfreq_coarse * nt_coarse)
@@ -666,6 +672,10 @@ public:
     // Instead use the static factory function assembed_chunk::make().
     assembled_chunk(const initializer &ini_params);
     virtual ~assembled_chunk();
+
+    // Returns C time() (seconds since the epoch, 1970.0) of the first/last sample in this chunk.
+    double time_begin() const;
+    double time_end() const;
 
     // The following virtual member functions have default implementations,
     // which are overridden by the subclass 'fast_assembled_chunk' to be faster

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -326,6 +326,8 @@ public:
 	int fpga_counts_per_sample = 384;
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
 
+        uint64_t frame0_nano = 0; // nanosecond time() value for fgpacount zero.
+        
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
 	std::string ipaddr = "0.0.0.0";
 	int udp_port = constants::default_udp_port;

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -275,6 +275,8 @@ public:
     // Moves any remaining active chunks into the ring buffer and sets 'doneflag'.
     void end_stream(int64_t *event_counts);
 
+    void set_frame0(uint64_t frame0_nano);
+    
     // Debugging: inject the given chunk
     bool inject_assembled_chunk(assembled_chunk* chunk);
 
@@ -325,6 +327,8 @@ protected:
     const int beam_id;
     const int stream_id;   // only used in assembled_chunk::format_filename().
 
+    uint64_t frame0_nano; // nanosecond time() value for fgpacount zero
+    
     output_device_pool output_devices;
 
     // Set to 'true' in the first call to put_unassembled_packet().

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -7,6 +7,9 @@
 #include <functional>
 #include <iostream>
 
+#include <curl/curl.h>
+#include <json/json.h>
+
 #include "ch_frb_io_internals.hpp"
 #include "chlog.hpp"
 
@@ -48,6 +51,7 @@ intensity_network_stream::intensity_network_stream(const initializer &ini_params
     network_thread_working_usec(0),
     assembler_thread_waiting_usec(0),
     assembler_thread_working_usec(0),
+    frame0_nano(ini_params.frame0_nano),
     stream_priority(0),
     stream_chunks_written(0),
     stream_bytes_written(0)
@@ -969,6 +973,77 @@ void intensity_network_stream::assembler_thread_main() {
     _assembler_thread_exit();
 }
 
+class CurlStringHolder {
+public:
+    string thestring;
+};
+
+static size_t
+CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    size_t realsize = size * nmemb;
+    CurlStringHolder* h = (CurlStringHolder*)userp;
+    h->thestring += string((char*)contents, realsize);
+    return realsize;
+}
+
+bool intensity_network_stream::_fetch_frame0() {
+    if (ini_params.frame0_url.size() == 0) {
+        cout << "No 'frame0_url' set; skipping." << endl;
+        return false;
+    }
+    CURL *curl_handle;
+    CURLcode res;
+    CurlStringHolder holder;
+    // init the curl session
+    curl_handle = curl_easy_init();
+    // specify URL to get
+    curl_easy_setopt(curl_handle, CURLOPT_URL, ini_params.frame0_url.c_str());
+    // set timeout
+    curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT_MS, 3000);
+    // set received-data callback
+    //frame0_txt = "";
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION,
+                     CurlWriteMemoryCallback);
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)(&holder));
+    // curl!
+    cout << "Fetching frame0_time from " << ini_params.frame0_url << endl;
+    res = curl_easy_perform(curl_handle);
+    if (res != CURLE_OK) {
+        cout << "Fetch_frame0 failed: " << string(curl_easy_strerror(res)) << endl;
+        return false;
+    }
+    curl_easy_cleanup(curl_handle);
+
+    string frame0_txt = holder.thestring;
+    
+    cout << "Received frame0 text: " << frame0_txt << endl;
+    Json::Reader frame0_reader;
+    Json::Value frame0_json;
+    if (!frame0_reader.parse(frame0_txt, frame0_json)) {
+        cout << "ch-frb-io: failed to parse 'frame0' string: '"
+             << frame0_txt << "'" << endl;
+        return false;
+    }
+    cout << "Parsed: " << frame0_json << endl;
+    if (!frame0_json.isObject()) {
+        cout << "ch-frb-io: 'frame0' was not a JSON 'Object' as expected" << endl;
+        return false;
+    }
+    string key = "frame0_nano";
+    if (!frame0_json.isMember(key)) {
+        cout << "ch-frb-io: 'frame0' did not contain key '" << key << "'" << endl;
+        return false;
+    }
+    const Json::Value v = frame0_json[key];
+    if (!v.isIntegral()) {
+        cout << "ch-frb-io: expected 'frame0[frame0_nano]' to be integral." << endl;
+        return false;
+    }
+    frame0_nano = v.asUInt64();
+    cout << "Found frame0_nano: " << frame0_nano << endl;
+    return true;
+}
 
 void intensity_network_stream::_assembler_thread_body()
 {
@@ -986,6 +1061,32 @@ void intensity_network_stream::_assembler_thread_body()
     struct timeval tva, tvb;
     tva = xgettimeofday();
 
+    // After we receive our first packet, we will go fetch the frame0_ctime
+    // via curl.  This is usually fast, so we'll do it in blocking mode.
+    if (this->ini_params.frame0_url.size()) {
+        while (1) {
+            // Wait for first packet
+            cout << "Waiting for packets..." << endl;
+            if (!unassembled_ringbuf->get_packet_list(packet_list))
+                continue;
+            break;
+        }
+        cout << "Retrieving frame0_ctime from " << this->ini_params.frame0_url << endl;
+
+        if (!_fetch_frame0()) {
+            // FIXME --- fetch failed.... now what?!
+            throw runtime_error("Failed to retrieve frame0_ctime");
+        }
+
+        for (unsigned int i = 0; i < assemblers.size(); i++) {
+            if (assemblers[i])
+                assemblers[i]->set_frame0(frame0_nano);
+        }
+        
+        // Just discard packet_list ?
+        cout << "Discarding " << packet_list->curr_npackets << " packets" << endl;
+    }
+    
     // Main packet loop
 
     while (1) {


### PR DESCRIPTION
In this branch, I wait until the first packet is received in intensity_network_stream and then curl for the frame0_ctime.

Confusingly, the code is still in place to retrieve the frame0_ctime in ch-frb-l1, and the resulting frame0 gets passed around.  Removing this would simplify things, if we decide we don't want that capability any more.
