### PR TITLE
RFI mask plumbing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 ####################################################################################################
 
 
-LIBS = -lhdf5 -llz4 -lzmq
+LIBS = -lhdf5 -llz4 -lzmq -ljsoncpp -lcurl
 
 OFILES = assembled_chunk.o \
 	assembled_chunk_ringbuf.o \
@@ -106,10 +106,10 @@ test-intensity-hdf5-file: test-intensity-hdf5-file.cpp $(INCFILES) libch_frb_io.
 	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io
 
 test-assembled-chunk: test-assembled-chunk.cpp $(INCFILES) $(OFILES)
-	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) -llz4 -lhdf5 -lzmq
+	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) $(LIBS)
 
 test-weakptr: test-weakptr.cpp $(INCFILES) $(OFILES)
-	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) -llz4 -lhdf5 -lzmq
+	$(CPP) $(CPP_LFLAGS) -o $@ $< $(OFILES) $(LIBS)
 
 test-misc: test-misc.cpp $(INCFILES) libch_frb_io.so
 	$(CPP) $(CPP_LFLAGS) -o $@ $< -lch_frb_io

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -464,6 +464,8 @@ void assembled_chunk::_check_downsample(const assembled_chunk *src1, const assem
 {
     if (!src1 || !src2)
 	throw runtime_error("ch_frb_io: null pointer passed to assembled_chunk::downsample()");
+    if (this->has_rfi_mask)
+	throw runtime_error("ch_frb_io: assembled_chunk::downsample() called, and has_rfi_mask=true in destination chunk");
 
     if (src1->binning != src2->binning)
         throw runtime_error("ch_frb_io: assembled_chunk::downsample(): mismatched binning");

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -546,6 +546,7 @@ void assembled_chunk::write_msgpack_file(const string &filename, bool compress, 
     // Construct a shared_ptr from this, carefully
     shared_ptr<assembled_chunk> shthis(shared_ptr<assembled_chunk>(), this);
     msgpack::packer<msgpack::fbuffer> packer(fb);
+    // The real deal: in assembled_chunk_msgpack.hpp
     pack_assembled_chunk(packer, shthis, compress, buffer);
 
     if (fclose(f))

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -52,7 +52,7 @@ struct memory_slab_layout {
     const int nb_data;
     const int nb_scales;
     const int nb_offsets;
-    const int nb_mask;
+    const int nb_rfimask;
     const int nb_ds_data;
     const int nb_ds_mask;
     const int nb_ds_w2;
@@ -61,7 +61,7 @@ struct memory_slab_layout {
     const int ib_data;
     const int ib_scales;
     const int ib_offsets;
-    const int ib_mask;
+    const int ib_rfimask;
     const int ib_ds_data;
     const int ib_ds_mask;
     const int ib_ds_w2;
@@ -69,7 +69,7 @@ struct memory_slab_layout {
 
     static int align(int nbytes) { return ((nbytes+63)/64) * 64; }
 
-    memory_slab_layout(int nupfreq, int nt_per_packet, int ndownfreq) :
+    memory_slab_layout(int nupfreq, int nt_per_packet, int nrfifreq) :
 	nfreq_c(constants::nfreq_coarse_tot),
 	nfreq_f(constants::nfreq_coarse_tot * nupfreq),
 	nt_f(constants::nt_per_assembled_chunk),
@@ -77,15 +77,15 @@ struct memory_slab_layout {
 	nb_data(nfreq_f * nt_f),
 	nb_scales(nfreq_c * nt_c * sizeof(float)),
 	nb_offsets(nfreq_c * nt_c * sizeof(float)),
-        nb_mask(ndownfreq * nt_f / 8 * sizeof(uint8_t)),
+        nb_rfimask(nrfifreq * nt_f / 8 * sizeof(uint8_t)),
 	nb_ds_data(nupfreq * (nt_f/2) * sizeof(float)),
 	nb_ds_mask(nupfreq * (nt_f/2) * sizeof(int)),
 	nb_ds_w2((nt_c/2) * sizeof(float)),
 	ib_data(0),
 	ib_scales(align(ib_data + nb_data)),
 	ib_offsets(align(ib_scales + nb_scales)),
-        ib_mask(align(ib_offsets + nb_offsets)),
-	ib_ds_data(align(ib_mask + nb_mask)),
+        ib_rfimask(align(ib_offsets + nb_offsets)),
+	ib_ds_data(align(ib_rfimask + nb_rfimask)),
 	ib_ds_mask(align(ib_ds_data + nb_ds_data)),
 	ib_ds_w2(align(ib_ds_mask + nb_ds_mask)),
 	slab_size(align(ib_ds_w2 + nb_ds_w2))
@@ -96,7 +96,7 @@ struct memory_slab_layout {
 assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params) :
     beam_id(ini_params.beam_id), 
     nupfreq(ini_params.nupfreq),
-    ndownfreq(ini_params.ndownfreq),
+    nrfifreq(ini_params.nrfifreq),
     nt_per_packet(ini_params.nt_per_packet),
     fpga_counts_per_sample(ini_params.fpga_counts_per_sample), 
     binning(ini_params.binning),
@@ -105,7 +105,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     nt_coarse(_nt_c(nt_per_packet)),
     nscales(constants::nfreq_coarse_tot * nt_coarse),
     ndata(constants::nfreq_coarse_tot * nupfreq * constants::nt_per_assembled_chunk),
-    nmaskbytes(ndownfreq * constants::nt_per_assembled_chunk / 8),
+    nrfimaskbytes(nrfifreq * constants::nt_per_assembled_chunk / 8),
     isample(ichunk * constants::nt_per_assembled_chunk),
     fpga_begin(ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
     fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample)
@@ -127,7 +127,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     if (ichunk > ichunk_max)
 	throw runtime_error("assembled_chunk constructor: bad 'ichunk' argument");
 
-    memory_slab_layout mc(nupfreq, nt_per_packet, ndownfreq);
+    memory_slab_layout mc(nupfreq, nt_per_packet, nrfifreq);
 
     if (ini_params.pool) {
 	if (!ini_params.slab)
@@ -154,8 +154,8 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     this->data = memory_slab.get() + mc.ib_data;
     this->scales = reinterpret_cast<float *> (memory_slab.get() + mc.ib_scales);
     this->offsets = reinterpret_cast<float *> (memory_slab.get() + mc.ib_offsets);
-    if (this->ndownfreq)
-        this->rfi_mask = reinterpret_cast<uint8_t *> (memory_slab.get() + mc.ib_mask);
+    if (this->nrfifreq)
+        this->rfi_mask = reinterpret_cast<uint8_t *> (memory_slab.get() + mc.ib_rfimask);
     else
         this->rfi_mask = nullptr;
     this->ds_data = reinterpret_cast<float *> (memory_slab.get() + mc.ib_ds_data);
@@ -191,14 +191,14 @@ void assembled_chunk::_deallocate()
     
 // Static member function
 ssize_t assembled_chunk::get_memory_slab_size(int nupfreq, int nt_per_packet,
-                                              int ndownfreq)
+                                              int nrfifreq)
 {
     if ((nupfreq <= 0) || (nupfreq > constants::max_allowed_nupfreq))
 	throw runtime_error("assembled_chunk::get_memory_slab_size(): bad 'nupfreq' argument");
     if ((nt_per_packet <= 0) || !is_power_of_two(nt_per_packet) || (nt_per_packet > constants::nt_per_assembled_chunk))
 	throw runtime_error("assembled_chunk::get_memory_slab_size(): bad 'nt_per_packet' argument");
 
-    memory_slab_layout mc(nupfreq, nt_per_packet, ndownfreq);
+    memory_slab_layout mc(nupfreq, nt_per_packet, nrfifreq);
     return mc.slab_size;
 }
 
@@ -266,8 +266,8 @@ void assembled_chunk::fill_with_copy(const shared_ptr<assembled_chunk> &x)
     if ((this->nupfreq != x->nupfreq) || (this->nt_per_packet != x->nt_per_packet))
 	throw runtime_error("assembled_chunk::fill_with_copy() called on non-conformable chunks");
 
-    if (this->ndownfreq != x->ndownfreq)
-	throw runtime_error("assembled_chunk::fill_with_copy() called on non-conformable chunks (ndownfreq)");
+    if (this->nrfifreq != x->nrfifreq)
+	throw runtime_error("assembled_chunk::fill_with_copy() called on non-conformable chunks (nrfifreq)");
 
     if (x.get() == this)
 	return;
@@ -275,7 +275,7 @@ void assembled_chunk::fill_with_copy(const shared_ptr<assembled_chunk> &x)
     memcpy(this->data, x->data, ndata);
     memcpy(this->scales, x->scales, nscales * sizeof(float));
     memcpy(this->offsets, x->offsets, nscales * sizeof(float));
-    memcpy(this->rfi_mask, x->rfi_mask, nmaskbytes);
+    memcpy(this->rfi_mask, x->rfi_mask, nrfimaskbytes);
 }
 
 

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -154,10 +154,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     this->data = memory_slab.get() + mc.ib_data;
     this->scales = reinterpret_cast<float *> (memory_slab.get() + mc.ib_scales);
     this->offsets = reinterpret_cast<float *> (memory_slab.get() + mc.ib_offsets);
-    if (this->nrfifreq)
-        this->rfi_mask = reinterpret_cast<uint8_t *> (memory_slab.get() + mc.ib_rfimask);
-    else
-        this->rfi_mask = nullptr;
+    this->rfi_mask = nrfifreq ? reinterpret_cast<uint8_t *> (memory_slab.get() + mc.ib_rfimask) : nullptr;
     this->ds_data = reinterpret_cast<float *> (memory_slab.get() + mc.ib_ds_data);
     this->ds_mask = reinterpret_cast<int *> (memory_slab.get() + mc.ib_ds_mask);
     this->ds_w2 = reinterpret_cast<float *> (memory_slab.get() + mc.ib_ds_w2);

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -108,12 +108,17 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     nrfimaskbytes(nrfifreq * constants::nt_per_assembled_chunk / 8),
     isample(ichunk * constants::nt_per_assembled_chunk),
     fpga_begin(ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
-    fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample)
+    fpga_end((ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample),
+    has_rfi_mask(false)
 {
     if ((beam_id < 0) || (beam_id > constants::max_allowed_beam_id))
 	throw runtime_error("assembled_chunk constructor: bad 'beam_id' argument");
     if ((nupfreq <= 0) || (nupfreq > constants::max_allowed_nupfreq))
 	throw runtime_error("assembled_chunk constructor: bad 'nupfreq' argument");
+    if (nrfifreq < 0)
+	throw runtime_error("assembled_chunk constructor: bad 'nrfifreq' argument");
+    if ((nrfifreq > 0) && ((constants::nfreq_coarse_tot * nupfreq) % nrfifreq))
+	throw runtime_error("assembled_chunk constructor: bad 'nrfifreq' argument");
     if ((nt_per_packet <= 0) || !is_power_of_two(nt_per_packet) || (nt_per_packet > constants::nt_per_assembled_chunk))
 	throw runtime_error("assembled_chunk constructor: bad 'nt_per_packet' argument");
     if ((fpga_counts_per_sample <= 0) || (fpga_counts_per_sample > constants::max_allowed_fpga_counts_per_sample))
@@ -187,13 +192,16 @@ void assembled_chunk::_deallocate()
 
     
 // Static member function
-ssize_t assembled_chunk::get_memory_slab_size(int nupfreq, int nt_per_packet,
-                                              int nrfifreq)
+ssize_t assembled_chunk::get_memory_slab_size(int nupfreq, int nt_per_packet, int nrfifreq)
 {
     if ((nupfreq <= 0) || (nupfreq > constants::max_allowed_nupfreq))
 	throw runtime_error("assembled_chunk::get_memory_slab_size(): bad 'nupfreq' argument");
     if ((nt_per_packet <= 0) || !is_power_of_two(nt_per_packet) || (nt_per_packet > constants::nt_per_assembled_chunk))
 	throw runtime_error("assembled_chunk::get_memory_slab_size(): bad 'nt_per_packet' argument");
+    if (nrfifreq < 0)
+	throw runtime_error("assembled_chunk::get_memory_slab_size(): bad 'nrfifreq' argument");
+    if ((nrfifreq > 0) && ((constants::nfreq_coarse_tot * nupfreq) % nrfifreq))
+	throw runtime_error("assembled_chunk::get_memory_slab_size(): bad 'nrfifreq' argument");
 
     memory_slab_layout mc(nupfreq, nt_per_packet, nrfifreq);
     return mc.slab_size;
@@ -262,7 +270,6 @@ void assembled_chunk::fill_with_copy(const shared_ptr<assembled_chunk> &x)
 	throw runtime_error("assembled_chunk::fill_with_copy() called with empty pointer");
     if ((this->nupfreq != x->nupfreq) || (this->nt_per_packet != x->nt_per_packet))
 	throw runtime_error("assembled_chunk::fill_with_copy() called on non-conformable chunks");
-
     if (this->nrfifreq != x->nrfifreq)
 	throw runtime_error("assembled_chunk::fill_with_copy() called on non-conformable chunks (nrfifreq)");
 
@@ -333,6 +340,8 @@ void assembled_chunk::add_packet(const intensity_packet &packet)
 
 
 // virtual member function; any changes made here should be reflected in override fast_assembled_chunk::decode().
+// Note: decode() and decode_subset() do not apply the RFI mask in assembled_chunk::rfi_mask (if this exists).
+
 void assembled_chunk::decode(float *intensity, float *weights, int istride, int wstride, float prescale) const
 {
     if (!intensity || !weights)
@@ -495,6 +504,9 @@ unique_ptr<assembled_chunk> assembled_chunk::make(const assembled_chunk::initial
 
 void assembled_chunk::write_hdf5_file(const string &filename)
 {
+    if (this->rfi_mask != nullptr)
+	throw runtime_error("ch_frb_io: assembled_chunk hdf5 format does not implement RFI mask yet");
+    
     bool write = true;
     bool clobber = true;
     hdf5_file f(filename, write, clobber);
@@ -536,6 +548,9 @@ void assembled_chunk::write_hdf5_file(const string &filename)
 
 void assembled_chunk::write_msgpack_file(const string &filename, bool compress, uint8_t *buffer)
 {
+    if ((this->rfi_mask != nullptr) && (!this->has_rfi_mask))
+	throw runtime_error("ch_frb_io::assembled_chunk::write_msgpack_file() called on chunk whose RFI mask has not been initialized yet");
+    
     char tempfilename[filename.size() + 10];
     sprintf(tempfilename, "%s.tmpXXXXXX", filename.c_str());
     int fd = mkstemp(tempfilename);

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -155,9 +155,9 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     this->scales = reinterpret_cast<float *> (memory_slab.get() + mc.ib_scales);
     this->offsets = reinterpret_cast<float *> (memory_slab.get() + mc.ib_offsets);
     if (this->ndownfreq)
-        this->mask = reinterpret_cast<uint8_t *> (memory_slab.get() + mc.ib_mask);
+        this->rfi_mask = reinterpret_cast<uint8_t *> (memory_slab.get() + mc.ib_mask);
     else
-        this->mask = nullptr;
+        this->rfi_mask = nullptr;
     this->ds_data = reinterpret_cast<float *> (memory_slab.get() + mc.ib_ds_data);
     this->ds_mask = reinterpret_cast<int *> (memory_slab.get() + mc.ib_ds_mask);
     this->ds_w2 = reinterpret_cast<float *> (memory_slab.get() + mc.ib_ds_w2);
@@ -182,7 +182,7 @@ void assembled_chunk::_deallocate()
     this->scales = nullptr;
     this->offsets = nullptr;
     this->data = nullptr;
-    this->mask = nullptr;
+    this->rfi_mask = nullptr;
     this->ds_w2 = nullptr;
     this->ds_data = nullptr;
     this->ds_mask = nullptr;
@@ -275,7 +275,7 @@ void assembled_chunk::fill_with_copy(const shared_ptr<assembled_chunk> &x)
     memcpy(this->data, x->data, ndata);
     memcpy(this->scales, x->scales, nscales * sizeof(float));
     memcpy(this->offsets, x->offsets, nscales * sizeof(float));
-    memcpy(this->mask, x->mask, nmaskbytes);
+    memcpy(this->rfi_mask, x->rfi_mask, nmaskbytes);
 }
 
 

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -539,6 +539,8 @@ void assembled_chunk::downsample(const assembled_chunk *src1, const assembled_ch
 			       src2->rfi_mask + ifreq * (nt_f/8),
 			       nt_f);
     }
+
+    this->has_rfi_mask = true;
 }
 
 

--- a/assembled_chunk.cpp
+++ b/assembled_chunk.cpp
@@ -97,6 +97,7 @@ assembled_chunk::assembled_chunk(const assembled_chunk::initializer &ini_params)
     binning(ini_params.binning),
     stream_id(ini_params.stream_id),
     ichunk(ini_params.ichunk),
+    frame0_nano(ini_params.frame0_nano),
     nt_coarse(_nt_c(nt_per_packet)),
     nscales(constants::nfreq_coarse_tot * nt_coarse),
     ndata(constants::nfreq_coarse_tot * nupfreq * constants::nt_per_assembled_chunk),
@@ -193,6 +194,15 @@ ssize_t assembled_chunk::get_memory_slab_size(int nupfreq, int nt_per_packet)
 
 // -------------------------------------------------------------------------------------------------
 
+// Nanoseconds per FPGA count
+static const uint64_t fpga_nano = 2560;
+
+double assembled_chunk::time_begin() const {
+    return (frame0_nano + fpga_counts_per_sample * fpga_nano * fpga_begin) * 1e-9;
+}
+
+double assembled_chunk::time_end() const {
+    return (frame0_nano + fpga_counts_per_sample * fpga_nano * fpga_end) * 1e-9;}
 
 static string 
 __attribute__ ((format(printf,1,2)))

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -115,7 +115,7 @@ void pack_assembled_chunk(msgpack::packer<Stream>& o,
     o.pack(ch->frame0_nano);
     // Item[18]
     o.pack(ch->nrfifreq);
-    o.pack(ch->has_rfi_mask);
+    o.pack(ch->has_rfi_mask.load());
     if (ch->rfi_mask) {
         // Item[20]
         o.pack_bin(ch->nrfimaskbytes);

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -104,11 +104,11 @@ void pack_assembled_chunk(msgpack::packer<Stream>& o,
                     nscalebytes);
     o.pack_bin(data_size);
     o.pack_bin_body(reinterpret_cast<const char*>(data.get()), data_size);
-    o.pack(ch->ndownfreq);
+    o.pack(ch->nrfifreq);
     o.pack(ch->has_rfi_mask);
     if (ch->rfi_mask) {
-        o.pack_bin(ch->nmaskbytes);
-        o.pack_bin_body(reinterpret_cast<const char*>(ch->rfi_mask), ch->nmaskbytes);
+        o.pack_bin(ch->nrfimaskbytes);
+        o.pack_bin_body(reinterpret_cast<const char*>(ch->rfi_mask), ch->nrfimaskbytes);
     } else {
         o.pack_bin(0);
     }

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -31,8 +31,8 @@ void pack_assembled_chunk(msgpack::packer<Stream>& o,
     // pack member variables as an array.
     //std::cout << "Pack shared_ptr<assembled-chunk> into msgpack object..." << std::endl;
     uint8_t version = 1;
-    // We are going to pack 17 items as a msgpack array (with mixed types)
-    o.pack_array(17);
+    // We are going to pack 20 items as a msgpack array (with mixed types)
+    o.pack_array(20);
     // Item 0: header string
     o.pack("assembled_chunk in msgpack format");
     // Item 1: version number
@@ -104,6 +104,14 @@ void pack_assembled_chunk(msgpack::packer<Stream>& o,
                     nscalebytes);
     o.pack_bin(data_size);
     o.pack_bin_body(reinterpret_cast<const char*>(data.get()), data_size);
+    o.pack(ch->ndownfreq);
+    o.pack(ch->has_rfi_mask);
+    if (ch->mask) {
+        o.pack_bin(ch->nmaskbytes);
+        o.pack_bin_body(reinterpret_cast<const char*>(ch->mask), ch->nmaskbytes);
+    } else {
+        o.pack_bin(0);
+    }
 }
 
 namespace msgpack {

--- a/assembled_chunk_msgpack.hpp
+++ b/assembled_chunk_msgpack.hpp
@@ -106,9 +106,9 @@ void pack_assembled_chunk(msgpack::packer<Stream>& o,
     o.pack_bin_body(reinterpret_cast<const char*>(data.get()), data_size);
     o.pack(ch->ndownfreq);
     o.pack(ch->has_rfi_mask);
-    if (ch->mask) {
+    if (ch->rfi_mask) {
         o.pack_bin(ch->nmaskbytes);
-        o.pack_bin_body(reinterpret_cast<const char*>(ch->mask), ch->nmaskbytes);
+        o.pack_bin_body(reinterpret_cast<const char*>(ch->rfi_mask), ch->nmaskbytes);
     } else {
         o.pack_bin(0);
     }

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -629,6 +629,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
     chunk_params.nupfreq = this->ini_params.nupfreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
+    chunk_params.frame0_nano = this->ini_params.frame0_nano;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;
     chunk_params.force_fast = this->ini_params.force_fast_kernels;
     chunk_params.stream_id = this->stream_id;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -14,6 +14,7 @@ assembled_chunk_ringbuf::assembled_chunk_ringbuf(const intensity_network_stream:
     ini_params(ini_params_),
     beam_id(beam_id_),
     stream_id(stream_id_),
+    frame0_nano(ini_params_.frame0_nano),
     output_devices(ini_params.output_devices)
 {
     if ((beam_id < 0) || (beam_id > constants::max_allowed_beam_id))
@@ -63,6 +64,10 @@ assembled_chunk_ringbuf::~assembled_chunk_ringbuf()
     pthread_mutex_destroy(&this->lock);
 }
 
+
+void assembled_chunk_ringbuf::set_frame0(uint64_t f0) {
+    frame0_nano = f0;
+}
 
 void assembled_chunk_ringbuf::print_state() 
 {
@@ -629,7 +634,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
     chunk_params.nupfreq = this->ini_params.nupfreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
-    chunk_params.frame0_nano = this->ini_params.frame0_nano;
+    chunk_params.frame0_nano = this->frame0_nano;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;
     chunk_params.force_fast = this->ini_params.force_fast_kernels;
     chunk_params.stream_id = this->stream_id;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -382,6 +382,14 @@ bool assembled_chunk_ringbuf::_put_assembled_chunk(unique_ptr<assembled_chunk> &
 
 	if (ids == nds-1) {
 	    poplist[2*ids] = this->ringbuf_entry(ids, ringbuf_pos[ids]);
+
+	    // This assert and its counterpart below ensure that a chunk never leaves the telescoping
+	    // ring buffer before its RFI mask is filled.  (If this could happen, we might hang on to
+	    // the reference forever in output_device::_awaiting_rfi and get a memory leak.)
+
+	    if ((ini_params.nrfifreq > 0) && !poplist[2*ids]->has_rfi_mask)
+		throw runtime_error("ch_frb_io: _put_assembled_chunk(): rfimask not initialized as expected, maybe your ring buffer is too small?");
+
 	    break;
 	}
 

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -648,6 +648,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
 
     chunk_params.beam_id = this->beam_id;
     chunk_params.nupfreq = this->ini_params.nupfreq;
+    chunk_params.ndownfreq = this->ini_params.ndownfreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;

--- a/assembled_chunk_ringbuf.cpp
+++ b/assembled_chunk_ringbuf.cpp
@@ -648,7 +648,7 @@ std::unique_ptr<assembled_chunk> assembled_chunk_ringbuf::_make_assembled_chunk(
 
     chunk_params.beam_id = this->beam_id;
     chunk_params.nupfreq = this->ini_params.nupfreq;
-    chunk_params.ndownfreq = this->ini_params.ndownfreq;
+    chunk_params.nrfifreq = this->ini_params.nrfifreq;
     chunk_params.nt_per_packet = this->ini_params.nt_per_packet;
     chunk_params.fpga_counts_per_sample = this->ini_params.fpga_counts_per_sample;
     chunk_params.force_reference = this->ini_params.force_reference_kernels;

--- a/avx2_kernels.cpp
+++ b/avx2_kernels.cpp
@@ -1023,6 +1023,7 @@ void fast_assembled_chunk::downsample(const assembled_chunk *src1, const assembl
 			   src2->rfi_mask + ifreq * (nt_f/8),
 			   nt_f);
     }
+    this->has_rfi_mask = true;
 }
 
 

--- a/avx2_kernels.cpp
+++ b/avx2_kernels.cpp
@@ -1023,6 +1023,7 @@ void fast_assembled_chunk::downsample(const assembled_chunk *src1, const assembl
 			   src2->rfi_mask + ifreq * (nt_f/8),
 			   nt_f);
     }
+    
     this->has_rfi_mask = true;
 }
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -500,16 +500,12 @@ public:
 
     ~intensity_network_stream();
 
-    int first_ichunk;
-
 protected:
     // Constant after construction, so not protected by lock
     std::vector<std::shared_ptr<assembled_chunk_ringbuf> > assemblers;
 
     // Used to exchange data between the network and assembler threads
     std::unique_ptr<udp_packet_ringbuf> unassembled_ringbuf;
-
-    bool got_first_packet;
 
     // Written by network thread, read by outside thread
     // How much wall time do we spend waiting in recvfrom() vs processing?

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -695,7 +695,7 @@ public:
 
     // False on initialization.
     // If the RFI mask is being saved (nrfifreq > 0), it will be subsequently set to True by the processing thread.
-    bool has_rfi_mask = false;
+    std::atomic<bool> has_rfi_mask;
 
     // Note: you probably don't want to call the assembled_chunk constructor directly!
     // Instead use the static factory function assembed_chunk::make().

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -322,7 +322,7 @@ public:
 	std::vector<std::shared_ptr<output_device>> output_devices;
 
 	int nupfreq = 0;
-	int ndownfreq = 0;
+	int nrfifreq = 0;
 	int nt_per_packet = 0;
 	int fpga_counts_per_sample = 384;
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
@@ -640,7 +640,7 @@ public:
     struct initializer {
 	int beam_id = 0;
 	int nupfreq = 0;
-        int ndownfreq = 0;
+        int nrfifreq = 0;
 	int nt_per_packet = 0;
 	int fpga_counts_per_sample = 0;
 	int binning = 1;
@@ -658,7 +658,7 @@ public:
     // Parameters specified at construction.
     const int beam_id = 0;
     const int nupfreq = 0;
-    const int ndownfreq = 0;
+    const int nrfifreq = 0;
     const int nt_per_packet = 0;
     const int fpga_counts_per_sample = 0;    // no binning factor applied here
     const int binning = 0;                   // either 1, 2, 4, 8... depending on level in telescoping ring buffer
@@ -669,7 +669,7 @@ public:
     const int nt_coarse = 0;          // equal to (constants::nt_per_assembled_chunk / nt_per_packet)
     const int nscales = 0;            // equal to (constants::nfreq_coarse * nt_coarse)
     const int ndata = 0;              // equal to (constants::nfreq_coarse * nupfreq * constants::nt_per_assembled_chunk)
-    const int nmaskbytes = 0;
+    const int nrfimaskbytes = 0;
     const uint64_t isample = 0;       // equal to ichunk * constants::nt_per_assembled_chunk
     const uint64_t fpga_begin = 0;    // equal to ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample
     const uint64_t fpga_end = 0;      // equal to (ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample
@@ -721,9 +721,9 @@ public:
     void fill_with_copy(const std::shared_ptr<assembled_chunk> &x);
     void randomize(std::mt19937 &rng);
 
-    // ndownfreq: number of frequencies in downsampled RFI chain processing
+    // nrfifreq: number of frequencies in downsampled RFI chain processing
     static ssize_t get_memory_slab_size(int nupfreq, int nt_per_packet,
-                                        int ndownfreq);
+                                        int nrfifreq);
 
     // I wanted to make the following fields protected, but msgpack doesn't like it...
 
@@ -731,7 +731,7 @@ public:
     float *scales = nullptr;   // 2d array of shape (constants::nfreq_coarse, nt_coarse)
     float *offsets = nullptr;  // 2d array of shape (constants::nfreq_coarse, nt_coarse)
     uint8_t *data = nullptr;   // 2d array of shape (constants::nfreq_coarse * nupfreq, constants::nt_per_assembled_chunk)
-    uint8_t *rfi_mask = nullptr;   // 2d array of downsampled masks, packed bitwise; (ndownfreq x constants::nt_per_assembled_chunk / 8 bits)
+    uint8_t *rfi_mask = nullptr;   // 2d array of downsampled masks, packed bitwise; (nrfifreq x constants::nt_per_assembled_chunk / 8 bits)
 
     bool has_rfi_mask = false;
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -731,7 +731,7 @@ public:
     float *scales = nullptr;   // 2d array of shape (constants::nfreq_coarse, nt_coarse)
     float *offsets = nullptr;  // 2d array of shape (constants::nfreq_coarse, nt_coarse)
     uint8_t *data = nullptr;   // 2d array of shape (constants::nfreq_coarse * nupfreq, constants::nt_per_assembled_chunk)
-    uint8_t *mask = nullptr;   // 2d array of downsampled masks, packed bitwise; (ndownfreq x constants::nt_per_assembled_chunk / 8 bits)
+    uint8_t *rfi_mask = nullptr;   // 2d array of downsampled masks, packed bitwise; (ndownfreq x constants::nt_per_assembled_chunk / 8 bits)
 
     bool has_rfi_mask = false;
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -855,6 +855,7 @@ struct write_chunk_request {
     // Called when the status of this chunk has changed --
     // due to an error, successful completion, or, eg, RFI mask added.
     virtual void status_changed(bool finished, bool success,
+                                const std::string &state,
                                 const std::string &error_message) { }
     virtual ~write_chunk_request() { }
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -678,6 +678,10 @@ public:
     const uint64_t fpga_begin = 0;    // equal to ichunk * constants::nt_per_assembled_chunk * fpga_counts_per_sample
     const uint64_t fpga_end = 0;      // equal to (ichunk+binning) * constants::nt_per_assembled_chunk * fpga_counts_per_sample
 
+    // False on initialization.
+    // If the RFI mask is being saved (nrfifreq > 0), it will be subsequently set to True by the processing thread.
+    bool has_rfi_mask = false;
+
     // Note: you probably don't want to call the assembled_chunk constructor directly!
     // Instead use the static factory function assembed_chunk::make().
     assembled_chunk(const initializer &ini_params);
@@ -692,6 +696,9 @@ public:
     // will be multiplied by its value.  This is a temporary workaround for some
     // 16-bit overflow issues in bonsai.  (We currently don't need prescaling
     // in decode_subset(), but this could be added easily.)
+    //
+    // Warning (FIXME?): decode() and decode_subset() do not apply the RFI mask
+    // in assembled_chunk::rfi_mask (if this exists).
 
     virtual void add_packet(const intensity_packet &p);
     virtual void decode(float *intensity, float *weights, int istride, int wstride, float prescale=1.0) const;
@@ -734,8 +741,6 @@ public:
     float *offsets = nullptr;  // 2d array of shape (constants::nfreq_coarse, nt_coarse)
     uint8_t *data = nullptr;   // 2d array of shape (constants::nfreq_coarse * nupfreq, constants::nt_per_assembled_chunk)
     uint8_t *rfi_mask = nullptr;   // 2d array of downsampled masks, packed bitwise; (nrfifreq x constants::nt_per_assembled_chunk / 8 bits)
-
-    bool has_rfi_mask = false;
 
     // Temporary buffers used during downsampling.
     float *ds_w2 = nullptr;    // 1d array of length (nt_coarse/2)

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -446,8 +446,10 @@ public:
     get_ringbuf_snapshots(const std::vector<int> &beams = std::vector<int>(),
                           uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 
-    // Searches for the top-level chunk for the given beam and fpgacounts start.
-    std::shared_ptr<assembled_chunk> find_assembled_chunk(int beam, uint64_t fpga_counts);
+    // Searches the telescoping ring buffer for the given beam and fpgacounts start.
+    // If 'toplevel' is true, then only the top level of the ring buffer is searched.
+    // If no chunk is found, then an exception will be thrown (i.e. empty pointer is never returned).
+    std::shared_ptr<assembled_chunk> find_assembled_chunk(int beam, uint64_t fpga_counts, bool toplevel=true);
 
     // If period = 0, returns the packet rate with timestamp closest
     // to *start*.  If *start* is zero or negative, it is interpreted

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -495,12 +495,16 @@ public:
 
     ~intensity_network_stream();
 
+    int first_ichunk;
+
 protected:
     // Constant after construction, so not protected by lock
     std::vector<std::shared_ptr<assembled_chunk_ringbuf> > assemblers;
 
     // Used to exchange data between the network and assembler threads
     std::unique_ptr<udp_packet_ringbuf> unassembled_ringbuf;
+
+    bool got_first_packet;
 
     // Written by network thread, read by outside thread
     // How much wall time do we spend waiting in recvfrom() vs processing?

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -334,7 +334,8 @@ public:
 
 	// If 'frame0_url' is a nonempty string, then assembler thread will retrieve frame0 info by "curling" the URL.
         std::string frame0_url = "";
-        
+        int frame0_timeout = 3000;
+
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
 	std::string ipaddr = "0.0.0.0";
 	int udp_port = constants::default_udp_port;
@@ -603,7 +604,9 @@ protected:
     // Private methods called by the assembler thread.     
     void _assembler_thread_body();
     void _assembler_thread_exit();
-    bool _fetch_frame0();  // initializes 'frame0_nano' by curling 'frame0_url', called when first packet is received
+    // initializes 'frame0_nano' by curling 'frame0_url', called when first packet is received.
+    // NOTE that one must call curl_global_init() before, and curl_global_cleanup() after; in chime-frb-l1 we do this in the top-level main() method.
+    void _fetch_frame0();
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -327,6 +327,7 @@ public:
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
 
         uint64_t frame0_nano = 0; // nanosecond time() value for fgpacount zero.
+        std::string frame0_url = "";
         
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
 	std::string ipaddr = "0.0.0.0";
@@ -515,6 +516,8 @@ protected:
     std::atomic<uint64_t> assembler_thread_waiting_usec;
     std::atomic<uint64_t> assembler_thread_working_usec;
 
+    uint64_t frame0_nano;
+
     char _pad1b[constants::cache_line_size];
 
     // Used only by the network thread (not protected by lock)
@@ -587,6 +590,8 @@ protected:
     // Private methods called by the assembler thread.     
     void _assembler_thread_body();
     void _assembler_thread_exit();
+
+    bool _fetch_frame0();
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -452,7 +452,8 @@ public:
 
     // Searches the telescoping ring buffer for the given beam and fpgacounts start.
     // If 'toplevel' is true, then only the top level of the ring buffer is searched.
-    // If no chunk is found, then an exception will be thrown (i.e. empty pointer is never returned).
+    // Returns an empty pointer iff stream has ended, and chunk is requested past end-of-stream.
+    // If anything else goes wrong, an exception will be thrown.
     std::shared_ptr<assembled_chunk> find_assembled_chunk(int beam, uint64_t fpga_counts, bool toplevel=true);
 
     // If period = 0, returns the packet rate with timestamp closest

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -1085,6 +1085,8 @@ public:
 
     void print_status(std::ostream &os = std::cout);
 
+    bool is_sending();
+
 protected:
     std::vector<uint16_t> beam_ids_16bit;
     std::vector<uint16_t> coarse_freq_ids_16bit;

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -852,7 +852,10 @@ struct write_chunk_request {
     int priority = 0;
     bool need_rfi_mask = false;
 
-    virtual void write_callback(const std::string &error_message) { }
+    // Called when the status of this chunk has changed --
+    // due to an error, successful completion, or, eg, RFI mask added.
+    virtual void status_changed(bool finished, bool success,
+                                const std::string &error_message) { }
     virtual ~write_chunk_request() { }
 
     // This comparator class is used below, to make an STL priority queue.

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -639,6 +639,9 @@ public:
 	bool force_reference = false;
 	bool force_fast = false;
 
+        // "ctime" in nanoseconds of FGPAcount zero
+        uint64_t frame0_nano = 0;
+
 	// If a memory slab has been preallocated from a pool, these pointers should be set.
 	// Otherwise, both pointers should be empty, and the assembled_chunk constructor will allocate.
 	std::shared_ptr<memory_slab_pool> pool;
@@ -653,7 +656,10 @@ public:
     const int binning = 0;                   // either 1, 2, 4, 8... depending on level in telescoping ring buffer
     const int stream_id = 0;
     const uint64_t ichunk = 0;
-    
+
+    // "ctime" in nanoseconds of FGPAcount zero
+    uint64_t frame0_nano = 0;
+
     // Derived parameters.
     const int nt_coarse = 0;          // equal to (constants::nt_per_assembled_chunk / nt_per_packet)
     const int nscales = 0;            // equal to (constants::nfreq_coarse * nt_coarse)
@@ -666,6 +672,10 @@ public:
     // Instead use the static factory function assembed_chunk::make().
     assembled_chunk(const initializer &ini_params);
     virtual ~assembled_chunk();
+
+    // Returns C time() (seconds since the epoch, 1970.0) of the first/last sample in this chunk.
+    double time_begin() const;
+    double time_end() const;
 
     // The following virtual member functions have default implementations,
     // which are overridden by the subclass 'fast_assembled_chunk' to be faster

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -703,7 +703,7 @@ public:
     virtual void add_packet(const intensity_packet &p);
     virtual void decode(float *intensity, float *weights, int istride, int wstride, float prescale=1.0) const;
     virtual void decode_subset(float *intensity, float *weights, int t0, int nt, int istride, int wstride) const;
-    virtual void downsample(const assembled_chunk *src1, const assembled_chunk *src2);
+    virtual void downsample(const assembled_chunk *src1, const assembled_chunk *src2);   // downsamples data and RFI mask
 
     // Static factory functions which can return either an assembled_chunk or a fast_assembled_chunk.
     static std::unique_ptr<assembled_chunk> make(const initializer &ini_params);
@@ -730,7 +730,7 @@ public:
 
     // Utility functions currently used only for testing.
     void fill_with_copy(const std::shared_ptr<assembled_chunk> &x);
-    void randomize(std::mt19937 &rng);
+    void randomize(std::mt19937 &rng);   // also randomizes rfi_mask (if it exists)
 
     static ssize_t get_memory_slab_size(int nupfreq, int nt_per_packet, int nrfifreq);
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -332,6 +332,7 @@ public:
 	int fpga_counts_per_sample = 384;
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
 
+	// If 'frame0_url' is a nonempty string, then assembler thread will retrieve frame0 info by "curling" the URL.
         std::string frame0_url = "";
         
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
@@ -526,7 +527,8 @@ protected:
     std::atomic<uint64_t> assembler_thread_waiting_usec;
     std::atomic<uint64_t> assembler_thread_working_usec;
 
-    uint64_t frame0_nano; // nanosecond time() value for fgpacount zero.
+    // Initialized by assembler thread when first packet is received, constant thereafter.
+    uint64_t frame0_nano = 0;  // nanosecond time() value for fgpacount zero.
 
     char _pad1b[constants::cache_line_size];
 
@@ -601,8 +603,7 @@ protected:
     // Private methods called by the assembler thread.     
     void _assembler_thread_body();
     void _assembler_thread_exit();
-
-    bool _fetch_frame0();
+    bool _fetch_frame0();  // initializes 'frame0_nano' by curling 'frame0_url', called when first packet is received
 };
 
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -440,6 +440,10 @@ public:
     get_ringbuf_snapshots(const std::vector<int> &beams = std::vector<int>(),
                           uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 
+    // Searches for the top-level chunk for the given beam and fpgacounts start.
+    std::shared_ptr<assembled_chunk> find_assembled_chunk(int beam,
+                                                          uint64_t fpga_counts);
+
     // If period = 0, returns the packet rate with timestamp closest
     // to *start*.  If *start* is zero or negative, it is interpreted
     // as seconds relative to now; otherwise as gettimeofday()

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -489,7 +489,7 @@ public:
     // Throws an exception if anything goes wrong!  When called from an RPC thread, caller will want to
     // wrap in try..except, and use exception::what() to get the error message.
 
-    void stream_to_files(const std::string &filename_pattern, const std::vector<int> &beam_ids, int priority);
+    void stream_to_files(const std::string &filename_pattern, const std::vector<int> &beam_ids, int priority, bool need_rfi);
 
     void get_streaming_status(std::string &filename_pattern,
                               std::vector<int> &beam_ids,
@@ -574,6 +574,7 @@ protected:
     std::string stream_filename_pattern;
     std::vector<int> stream_beam_ids;
     int stream_priority;
+    bool stream_rfi_mask;
     int stream_chunks_written;
     size_t stream_bytes_written;
 

--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -326,6 +326,8 @@ public:
 	int fpga_counts_per_sample = 384;
 	int stream_id = 0;   // only used in assembled_chunk::format_filename().
 
+        uint64_t frame0_nano = 0; // nanosecond time() value for fgpacount zero.
+        
 	// If ipaddr="0.0.0.0", then network thread will listen on all interfaces.
 	std::string ipaddr = "0.0.0.0";
 	int udp_port = constants::default_udp_port;

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -271,8 +271,8 @@ public:
 
     void put_unassembled_packet(const intensity_packet &packet, int64_t *event_counts);
     
-    // Called when the assembler thread exits.  
-    // Moves any remaining active chunks into the ring buffer and sets 'doneflag'.
+    // Called by the assembler thread, when it exits.
+    // Moves any remaining active chunks into the ring buffer, sets 'doneflag', initializes 'final_fpga'.
     void end_stream(int64_t *event_counts);
 
     void set_frame0(uint64_t frame0_nano);
@@ -302,6 +302,8 @@ public:
 
     // Find an assembled_chunk with the given fpgacounts start time, if it exists in the ring buffer.
     // Called by processing threads, in order to fill the RFI mask.
+    // Returns an empty pointer iff stream has ended, and chunk is requested past end-of-stream.
+    // If anything else goes wrong, an exception will be thrown.
     std::shared_ptr<assembled_chunk> find_assembled_chunk(uint64_t fpga_counts, bool top_level_only=false);
                                                           
 
@@ -397,6 +399,7 @@ protected:
     size_t stream_bytes_written = 0;
 
     bool doneflag = false;
+    uint64_t final_fpga = 0;   // last fpga count which has an assembled_chunk, only initialized when 'doneflag' is set to true.
 };
 
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -275,6 +275,8 @@ public:
     // Moves any remaining active chunks into the ring buffer and sets 'doneflag'.
     void end_stream(int64_t *event_counts);
 
+    void set_frame0(uint64_t frame0_nano);
+    
     // Debugging: inject the given chunk
     bool inject_assembled_chunk(assembled_chunk* chunk);
 
@@ -325,6 +327,8 @@ protected:
     const int beam_id;
     const int stream_id;   // only used in assembled_chunk::format_filename().
 
+    uint64_t frame0_nano; // nanosecond time() value for fgpacount zero
+    
     output_device_pool output_devices;
 
     // Set to 'true' in the first call to put_unassembled_packet().

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -281,7 +281,8 @@ public:
     // For debugging/testing: stream data to disk.  
     //   'filename pattern': see assembled_chunk::format_filename (empty string to turn off streaming)
     //   'priority': see write_chunk_request::priority
-    void stream_to_files(const std::string &filename_pattern, int priority);
+    void stream_to_files(const std::string &filename_pattern, int priority,
+                         bool need_rfi);
 
     // Callback from the write thread when a stream_to_files() write finishes
     void chunk_streamed(const std::string &filename);
@@ -387,6 +388,7 @@ protected:
     // Are we streaming data to disk?  (Note: these fields require the lock for either read or write access.)
     std::string stream_pattern;
     int stream_priority = 0;
+    bool stream_rfi_mask = false;
     int stream_chunks_written = 0;
     size_t stream_bytes_written = 0;
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -297,6 +297,11 @@ public:
     // to indicate end-of-stream.
     std::shared_ptr<assembled_chunk> get_assembled_chunk(bool wait=true);
 
+    // Find an assembled_chunk with the given fpgacounts start time, if it
+    // exists in the ring buffer
+    std::shared_ptr<assembled_chunk> find_assembled_chunk(uint64_t fpga_counts,
+                                                          bool top_level_only=false);
+
     // The return value is a vector of (chunk, where) pairs, where 'where' is of type enum l1_ringbuf_level (defined in ch_frb_io.hpp)
     std::vector<std::pair<std::shared_ptr<assembled_chunk>, uint64_t>> get_ringbuf_snapshot(uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);
 

--- a/ch_frb_io_internals.hpp
+++ b/ch_frb_io_internals.hpp
@@ -297,10 +297,10 @@ public:
     // to indicate end-of-stream.
     std::shared_ptr<assembled_chunk> get_assembled_chunk(bool wait=true);
 
-    // Find an assembled_chunk with the given fpgacounts start time, if it
-    // exists in the ring buffer
-    std::shared_ptr<assembled_chunk> find_assembled_chunk(uint64_t fpga_counts,
-                                                          bool top_level_only=false);
+    // Find an assembled_chunk with the given fpgacounts start time, if it exists in the ring buffer.
+    // Called by processing threads, in order to fill the RFI mask.
+    std::shared_ptr<assembled_chunk> find_assembled_chunk(uint64_t fpga_counts, bool top_level_only=false);
+                                                          
 
     // The return value is a vector of (chunk, where) pairs, where 'where' is of type enum l1_ringbuf_level (defined in ch_frb_io.hpp)
     std::vector<std::pair<std::shared_ptr<assembled_chunk>, uint64_t>> get_ringbuf_snapshot(uint64_t min_fpga_counts=0, uint64_t max_fpga_counts=0);

--- a/chlog.cpp
+++ b/chlog.cpp
@@ -341,7 +341,7 @@ void chime_log_server::run() {
                 break;
             }
 
-            if (!pollitems[0].revents & ZMQ_POLLIN) {
+            if (!(pollitems[0].revents & ZMQ_POLLIN)) {
                 cout << "log server: no input ready" << endl;
                 continue;
             }

--- a/intensity_network_ostream.cpp
+++ b/intensity_network_ostream.cpp
@@ -510,6 +510,13 @@ void intensity_network_ostream::_send_end_of_stream_packets()
     }
 }
 
+bool intensity_network_ostream::is_sending() {
+    int currsize = 0;
+    int maxsize = 0;
+    ringbuf->get_size(&currsize, &maxsize);
+    cout << "intensity_network_ostream::is_sending: buffer size " << currsize << "/" << maxsize << endl;
+    return (currsize > 0);
+}
 
 void intensity_network_ostream::print_status(ostream &os)
 {

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -620,6 +620,21 @@ intensity_network_stream::get_statistics() {
     return R;
 }
 
+std::shared_ptr<assembled_chunk>
+intensity_network_stream::find_assembled_chunk(int beam, uint64_t fpga_counts)
+{
+    std::shared_ptr<assembled_chunk> chunk;
+    // Which of my assemblers (if any) is handling the requested beam?
+    int nbeams = this->ini_params.beam_ids.size();
+    for (int i=0; i<nbeams; i++) {
+        if (this->ini_params.beam_ids[i] != beam)
+            continue;
+        chunk = this->assemblers[i]->find_assembled_chunk(fpga_counts, true);
+        break;
+    }
+    return chunk;
+}
+
 vector< vector< pair<shared_ptr<assembled_chunk>, uint64_t> > >
 intensity_network_stream::get_ringbuf_snapshots(const vector<int> &beams,
                                                 uint64_t min_fpga_counts,

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -259,7 +259,7 @@ void intensity_network_stream::join_threads()
 }
 
 
-void intensity_network_stream::stream_to_files(const string &filename_pattern, const vector<int> &beam_ids, int priority)
+void intensity_network_stream::stream_to_files(const string &filename_pattern, const vector<int> &beam_ids, int priority, bool need_rfi)
 {
     // Throw exception if 'beam_ids' argument contains a beam_id which is not
     // actually processed by this stream.
@@ -277,14 +277,15 @@ void intensity_network_stream::stream_to_files(const string &filename_pattern, c
     this->stream_filename_pattern = filename_pattern;
     this->stream_beam_ids = beam_ids;
     this->stream_priority = priority;
+    this->stream_rfi_mask = need_rfi;
     this->stream_chunks_written = 0;
     this->stream_bytes_written = 0;
     
     for (int ibeam = 0; ibeam < (int)ini_params.beam_ids.size(); ibeam++) {
 	if (vcontains(beam_ids, ini_params.beam_ids[ibeam]))
-	    assemblers[ibeam]->stream_to_files(filename_pattern, priority);
+	    assemblers[ibeam]->stream_to_files(filename_pattern, priority, need_rfi);
 	else
-	    assemblers[ibeam]->stream_to_files("", 0);
+	    assemblers[ibeam]->stream_to_files("", 0, false);
     }
 }
 

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -627,13 +627,13 @@ intensity_network_stream::get_statistics() {
 }
 
 std::shared_ptr<assembled_chunk>
-intensity_network_stream::find_assembled_chunk(int beam, uint64_t fpga_counts)
+intensity_network_stream::find_assembled_chunk(int beam, uint64_t fpga_counts, bool toplevel)
 {
     // Which of my assemblers (if any) is handling the requested beam?
     int nbeams = this->ini_params.beam_ids.size();
     for (int i=0; i<nbeams; i++)
         if (this->ini_params.beam_ids[i] == beam)
-	    return this->assemblers[i]->find_assembled_chunk(fpga_counts, true);
+	    return this->assemblers[i]->find_assembled_chunk(fpga_counts, toplevel);
 
     throw runtime_error("ch_frb_io internal error: beam_id mismatch in intensity_network_stream::find_assembled_chunk()");
 }

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -7,6 +7,9 @@
 #include <functional>
 #include <iostream>
 
+#include <curl/curl.h>
+#include <json/json.h>
+
 #include "ch_frb_io_internals.hpp"
 #include "chlog.hpp"
 
@@ -48,6 +51,7 @@ intensity_network_stream::intensity_network_stream(const initializer &ini_params
     network_thread_working_usec(0),
     assembler_thread_waiting_usec(0),
     assembler_thread_working_usec(0),
+    frame0_nano(ini_params.frame0_nano),
     stream_priority(0),
     stream_chunks_written(0),
     stream_bytes_written(0)
@@ -969,6 +973,77 @@ void intensity_network_stream::assembler_thread_main() {
     _assembler_thread_exit();
 }
 
+class CurlStringHolder {
+public:
+    string thestring;
+};
+
+static size_t
+CurlWriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+    size_t realsize = size * nmemb;
+    CurlStringHolder* h = (CurlStringHolder*)userp;
+    h->thestring += string((char*)contents, realsize);
+    return realsize;
+}
+
+bool intensity_network_stream::_fetch_frame0() {
+    if (ini_params.frame0_url.size() == 0) {
+        cout << "No 'frame0_url' set; skipping." << endl;
+        return false;
+    }
+    CURL *curl_handle;
+    CURLcode res;
+    CurlStringHolder holder;
+    // init the curl session
+    curl_handle = curl_easy_init();
+    // specify URL to get
+    curl_easy_setopt(curl_handle, CURLOPT_URL, ini_params.frame0_url.c_str());
+    // set timeout
+    curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT_MS, 3000);
+    // set received-data callback
+    //frame0_txt = "";
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION,
+                     CurlWriteMemoryCallback);
+    curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)(&holder));
+    // curl!
+    cout << "Fetching frame0_time from " << ini_params.frame0_url << endl;
+    res = curl_easy_perform(curl_handle);
+    if (res != CURLE_OK) {
+        cout << "Fetch_frame0 failed: " << string(curl_easy_strerror(res)) << endl;
+        return false;
+    }
+    curl_easy_cleanup(curl_handle);
+
+    string frame0_txt = holder.thestring;
+    
+    cout << "Received frame0 text: " << frame0_txt << endl;
+    Json::Reader frame0_reader;
+    Json::Value frame0_json;
+    if (!frame0_reader.parse(frame0_txt, frame0_json)) {
+        cout << "ch-frb-io: failed to parse 'frame0' string: '"
+             << frame0_txt << "'" << endl;
+        return false;
+    }
+    cout << "Parsed: " << frame0_json << endl;
+    if (!frame0_json.isObject()) {
+        cout << "ch-frb-io: 'frame0' was not a JSON 'Object' as expected" << endl;
+        return false;
+    }
+    string key = "frame0_nano";
+    if (!frame0_json.isMember(key)) {
+        cout << "ch-frb-io: 'frame0' did not contain key '" << key << "'" << endl;
+        return false;
+    }
+    const Json::Value v = frame0_json[key];
+    if (!v.isIntegral()) {
+        cout << "ch-frb-io: expected 'frame0[frame0_nano]' to be integral." << endl;
+        return false;
+    }
+    frame0_nano = v.asUInt64();
+    cout << "Found frame0_nano: " << frame0_nano << endl;
+    return true;
+}
 
 void intensity_network_stream::_assembler_thread_body()
 {
@@ -986,6 +1061,32 @@ void intensity_network_stream::_assembler_thread_body()
     struct timeval tva, tvb;
     tva = xgettimeofday();
 
+    // After we receive our first packet, we will go fetch the frame0_ctime
+    // via curl.  This is usually fast, so we'll do it in blocking mode.
+    if (this->ini_params.frame0_url.size()) {
+        while (1) {
+            // Wait for first packet
+            cout << "Waiting for packets..." << endl;
+            if (!unassembled_ringbuf->get_packet_list(packet_list))
+                continue;
+            break;
+        }
+        cout << "Retrieving frame0_ctime from " << this->ini_params.frame0_url << endl;
+
+        if (!_fetch_frame0()) {
+            // FIXME --- fetch failed.... now what?!
+            throw runtime_error("Failed to retrieve frame0_ctime");
+        }
+
+        for (unsigned int i = 0; i < assemblers.size(); i++) {
+            if (assemblers[i])
+                assemblers[i]->set_frame0(frame0_nano);
+        }
+        
+        // Just discard packet_list ?
+        cout << "Discarding " << packet_list->curr_npackets << " packets" << endl;
+    }
+    
     // Main packet loop
 
     while (1) {

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -44,8 +44,6 @@ shared_ptr<intensity_network_stream> intensity_network_stream::make(const initia
 
 intensity_network_stream::intensity_network_stream(const initializer &ini_params_) :
     ini_params(ini_params_),
-    first_ichunk(0),
-    got_first_packet(false),
     network_thread_waiting_usec(0),
     network_thread_working_usec(0),
     assembler_thread_waiting_usec(0),
@@ -1067,15 +1065,6 @@ void intensity_network_stream::_assembler_thread_body()
 	    int nfreq_coarse = packet.nfreq_coarse;
 	    int new_data_nbytes = nfreq_coarse * packet.nupfreq * packet.ntsamp;
 	    const int *assembler_beam_ids = &ini_params.beam_ids[0];  // bare pointer for speed
-
-            if (_unlikely(!got_first_packet)) {
-                // This assumes (reasonably) that the FPGA counts for the different beams are identical.
-                got_first_packet = true;
-                uint64_t packet_t0 = packet.fpga_count / packet.fpga_counts_per_sample;
-                first_ichunk = packet_t0 / constants::nt_per_assembled_chunk;
-                cout << "Got first packet.  FPGA count " << packet.fpga_count
-                     << " -> first ichunk " << first_ichunk << endl;
-            }
 
 	    // Danger zone: we modify the packet by leaving its pointers in place, but shortening its
 	    // length fields.  The new packet corresponds to a subset of the original packet containing

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -531,11 +531,11 @@ intensity_network_stream::get_statistics() {
 
     // output_device status
     int nqueued = 0;
-    for (int i=0; i<this->ini_params.output_devices.size(); i++) {
+    for (size_t i=0; i<this->ini_params.output_devices.size(); i++) {
         string name = this->ini_params.output_devices[i]->ini_params.device_name;
         int chunks = this->ini_params.output_devices[i]->count_queued_write_requests();
         nqueued += chunks;
-        for (int j=0; j<name.size(); j++)
+        for (size_t j=0; j<name.size(); j++)
             if ((name[j] == '/') || (name[j] == '-'))
                 name[j] = '_';
         m["output_chunks_queued_" + name] = chunks;
@@ -564,7 +564,7 @@ intensity_network_stream::get_statistics() {
                                    streaming_priority, streaming_chunks_written,
                                    streaming_bytes_written);
         m["streaming_n_beams"] = this->stream_beam_ids.size();
-        for (int i=0; i<this->stream_beam_ids.size(); i++)
+        for (unsigned int i=0; i<this->stream_beam_ids.size(); i++)
             m[stringprintf("streaming_beam_%i", i)] = this->stream_beam_ids[i];
         m["streaming_priority"] = this->stream_priority;
         m["streaming_bytes_written"] = this->stream_chunks_written;

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -80,9 +80,10 @@ void output_device::io_thread_main()
 	try {
 	    if (file_exists(w->filename))
 		throw runtime_error("Assembled chunk msgpack file to be written already exists: " + w->filename);
-	    else if (link_src.size() == 0)
+	    else if (link_src.size() == 0) {
+                //sleep(3);
 		chunk->write_msgpack_file(w->filename, false, this->_buffer.get());  // compress=false
-	    else {
+            } else {
 		if (ini_params.verbosity >= 3)
 		    chlog("write request '" + w->filename + "' is a pseudo-duplicate, will hard-link from '" + link_src + "' instead of writing new copy");
 		hard_link(link_src, w->filename);
@@ -197,10 +198,10 @@ shared_ptr<write_chunk_request> output_device::pop_write_request()
             if ((*req)->chunk->has_rfi_mask) {
                 cout << "Chunk " << (*req)->filename << " got its RFI mask!" << endl;
                 _write_reqs.push((*req));
+                (*req)->status_changed(false, true, "QUEUED", "RFI mask received; queued for writing");
                 auto toerase = req;
                 req--;
                 _awaiting_rfi.erase(toerase);
-                (*req)->status_changed(false, true, "QUEUED", "RFI mask received; queued for writing");
             }
         }
 	if (!_write_reqs.empty())

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -159,7 +159,7 @@ int output_device::count_queued_write_requests() {
 }
 
 void output_device::filled_rfi_mask(const std::shared_ptr<assembled_chunk> &chunk) {
-    // FIXME -- simplest approach -- tell waiters that something (may
+    // FIXME? -- simplest approach -- tell waiters that something (may
     // have) happened!
     unique_lock<std::mutex> ulock(_lock);
     _cond.notify_all();
@@ -175,8 +175,9 @@ shared_ptr<write_chunk_request> output_device::pop_write_request()
         // Check whether any chunks that were waiting for RFI masks to be
         // filled in have been.
         for (auto req=_awaiting_rfi.begin(); req!=_awaiting_rfi.end(); req++) {
-            if (req->chunk->has_rfi_mask) {
-                _write_reqs.push(req);
+            if ((*req)->chunk->has_rfi_mask) {
+                cout << "Chunk " << (*req)->filename << " got its RFI mask!" << endl;
+                _write_reqs.push((*req));
                 auto toerase = req;
                 req--;
                 _awaiting_rfi.erase(toerase);

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -138,8 +138,10 @@ bool output_device::enqueue_write_request(const shared_ptr<write_chunk_request> 
 
     unique_lock<std::mutex> ulock(_lock);
 
-    if (end_stream_called)
+    if (end_stream_called) {
+        req->status_changed(true, false, "FAILED", "stream ending");
 	return false;
+    }
 
     if (req->need_rfi_mask && !req->chunk->has_rfi_mask) {
         _awaiting_rfi.push_back(req);

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -131,7 +131,7 @@ bool output_device::enqueue_write_request(const shared_ptr<write_chunk_request> 
 	// or by checking this error condition in advance.)
     
 	throw runtime_error("ch_frb_io: enqueue_write_request() was called with need_rfi_mask=true,"
-			    + " but this server instance is not saving the RFI mask");
+			    " but this server instance is not saving the RFI mask");
     }
 
     unique_lock<std::mutex> ulock(_lock);

--- a/output_device.cpp
+++ b/output_device.cpp
@@ -122,6 +122,17 @@ bool output_device::enqueue_write_request(const shared_ptr<write_chunk_request> 
 	throw runtime_error("ch_frb_io::output_device::enqueue_write_request(): req->filename is an empty string");
     if (!is_prefix(this->ini_params.device_name, req->filename))
 	throw runtime_error("ch_frb_io::output_device::enqueue_write_request(): req->filename, device_name mismatch");
+    
+    if (req->need_rfi_mask && (req->chunk->nrfifreq <= 0)) {
+
+	// I decided to throw an exception here, instead of returning false,
+	// so that we get a "verbose" error message instead of an undiagnosed failure.
+	// (The L1 server is responsible for not crashing, either by catching the exception
+	// or by checking this error condition in advance.)
+    
+	throw runtime_error("ch_frb_io: enqueue_write_request() was called with need_rfi_mask=true,"
+			    + " but this server instance is not saving the RFI mask");
+    }
 
     unique_lock<std::mutex> ulock(_lock);
 

--- a/output_device_pool.cpp
+++ b/output_device_pool.cpp
@@ -36,6 +36,17 @@ output_device_pool::output_device_pool(const vector<shared_ptr<output_device>> &
 
 bool output_device_pool::enqueue_write_request(const shared_ptr<write_chunk_request> &req)
 {
+    if (req->need_rfi_mask && (req->chunk->nrfifreq <= 0)) {
+
+	// I decided to throw an exception here, instead of returning false,
+	// so that we get a "verbose" error message instead of an undiagnosed failure.
+	// (The L1 server is responsible for not crashing, either by catching the exception
+	// or by checking this error condition in advance.)
+    
+	throw runtime_error("ch_frb_io: enqueue_write_request() was called with need_rfi_mask=true,"
+			    + " but this server instance is not saving the RFI mask");
+    }
+	  
     if (req->filename.size() == 0)
 	return false;
 

--- a/output_device_pool.cpp
+++ b/output_device_pool.cpp
@@ -44,7 +44,7 @@ bool output_device_pool::enqueue_write_request(const shared_ptr<write_chunk_requ
 	// or by checking this error condition in advance.)
     
 	throw runtime_error("ch_frb_io: enqueue_write_request() was called with need_rfi_mask=true,"
-			    + " but this server instance is not saving the RFI mask");
+			    " but this server instance is not saving the RFI mask");
     }
 	  
     if (req->filename.size() == 0)

--- a/site/Makefile.local.frb-compute-0
+++ b/site/Makefile.local.frb-compute-0
@@ -1,13 +1,13 @@
 # Makefile.local for frb1.physics.mcgill.ca
 
 # Directory where C++ libraries will be installed
-LIBDIR=$(HOME)/lib
+LIBDIR ?= $(HOME)/lib
 
 # Directory where C++ header files will be installed
-INCDIR=$(HOME)/include
+INCDIR ?= $(HOME)/include
 
 # Directory where executables will be installed
-BINDIR=$(HOME)/bin
+BINDIR ?= $(HOME)/bin
 
 #
 # C++ command line

--- a/site/Makefile.local.frb-compute-0
+++ b/site/Makefile.local.frb-compute-0
@@ -25,3 +25,6 @@ else
 endif
 
 CPP_LFLAGS=-L. -L$(LIBDIR)
+
+CPP += $(shell pkg-config --cflags jsoncpp)
+CPP_LFLAGS += $(shell pkg-config --libs jsoncpp)

--- a/site/Makefile.local.orangutan
+++ b/site/Makefile.local.orangutan
@@ -18,6 +18,6 @@ BINDIR ?= $(HOME)/bin
 # Don't forget -pthread and -fPIC
 #
 
-CPP := g++ -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -I. -I$(INCDIR)
+CPP := g++ -std=c++11 -pthread -fPIC -Wall -O3 -march=native -ffast-math -I. -I$(INCDIR) -I/usr/include/jsoncpp
 
 CPP_LFLAGS := -L. -L$(LIBDIR)

--- a/test-weakptr.cpp
+++ b/test-weakptr.cpp
@@ -9,13 +9,14 @@ int main() {
     int nupfreq = 4;
     int nt_per_packet = 16;
     int fpgacounts = 400;
+    int ndownfreq = 1024;
     
     output_device::initializer out_ini;
     //memset(&out_ini, 0, sizeof(output_device::initializer));
     out_ini.device_name = "/tmp";
     out_ini.verbosity = 3;
 
-    int nbytes_per_memory_slab = assembled_chunk::get_memory_slab_size(nupfreq, nt_per_packet);
+    int nbytes_per_memory_slab = assembled_chunk::get_memory_slab_size(nupfreq, nt_per_packet, ndownfreq);
     shared_ptr<memory_slab_pool> pool = make_shared<memory_slab_pool>(nbytes_per_memory_slab, 10, vector<int>(), 1);
 
     intensity_network_stream::initializer ini_params;

--- a/test-weakptr.cpp
+++ b/test-weakptr.cpp
@@ -27,7 +27,7 @@ int main() {
     ini_params.fpga_counts_per_sample = fpgacounts;
 
     shared_ptr<assembled_chunk_ringbuf> assembler = make_shared<assembled_chunk_ringbuf>(ini_params, 1, 2);
-    assembler->stream_to_files("/tmp/(CHUNK).msgpack", -1000);
+    assembler->stream_to_files("/tmp/(CHUNK).msgpack", -1000, false);
 
     assembled_chunk::initializer chunk_ini;
     chunk_ini.pool = pool;

--- a/test-weakptr.cpp
+++ b/test-weakptr.cpp
@@ -9,14 +9,14 @@ int main() {
     int nupfreq = 4;
     int nt_per_packet = 16;
     int fpgacounts = 400;
-    int ndownfreq = 1024;
+    int nrfifreq = 1024;
     
     output_device::initializer out_ini;
     //memset(&out_ini, 0, sizeof(output_device::initializer));
     out_ini.device_name = "/tmp";
     out_ini.verbosity = 3;
 
-    int nbytes_per_memory_slab = assembled_chunk::get_memory_slab_size(nupfreq, nt_per_packet, ndownfreq);
+    int nbytes_per_memory_slab = assembled_chunk::get_memory_slab_size(nupfreq, nt_per_packet, nrfifreq);
     shared_ptr<memory_slab_pool> pool = make_shared<memory_slab_pool>(nbytes_per_memory_slab, 10, vector<int>(), 1);
 
     intensity_network_stream::initializer ini_params;


### PR DESCRIPTION
- add 'rfi_mask' field to assembled_chunk (including to msgpack outputs)
- add intensity_network_stream::find_assembled_chunk() by FPGA count
- when writing chunks: wait for RFI masks, if requested
