### PR TITLE
RFI mask monitoring

### DIFF
--- a/ch_frb_io.hpp
+++ b/ch_frb_io.hpp
@@ -549,8 +549,8 @@ protected:
     std::atomic<uint64_t> assembler_thread_waiting_usec;
     std::atomic<uint64_t> assembler_thread_working_usec;
 
-    // Initialized by assembler thread when first packet is received, constant thereafter.
-    uint64_t frame0_nano = 0;  // nanosecond time() value for fgpacount zero.
+    // Initialized to zero by constructor, set to nonzero value by assembler thread when first packet is received.
+    std::atomic<uint64_t> frame0_nano;  // nanosecond time() value for fgpacount zero.
 
     char _pad1b[constants::cache_line_size];
 

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -1251,13 +1251,13 @@ void intensity_network_stream::_fetch_frame0() {
     curl_easy_cleanup(curl_handle);
 
     string frame0_txt = holder.thestring;
-    chlog("Received frame0 text: " << frame0_txt);
+    //chlog("Received frame0 text: " << frame0_txt);
     Json::Reader frame0_reader;
     Json::Value frame0_json;
     if (!frame0_reader.parse(frame0_txt, frame0_json))
         throw runtime_error("ch_frb_io: failed to parse 'frame0' string: '" + frame0_txt + "'");
 
-    chlog("Parsed: " << frame0_json);
+    //chlog("Parsed: " << frame0_json);
     if (!frame0_json.isObject())
         throw runtime_error("ch_frb_io: 'frame0' was not a JSON 'Object' as expected");
 

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -717,6 +717,8 @@ void intensity_network_stream::network_thread_main()
     // We use try..catch to ensure that _network_thread_exit() always gets called, even if an exception is thrown.
     // We also print the exception so that it doesn't get "swallowed".
 
+    chime_log_set_thread_name("Network-" + std::to_string(ini_params.stream_id));
+
     try {
 	_network_thread_body();   // calls pin_thread_to_cores()
     } catch (exception &e) {
@@ -1004,6 +1006,8 @@ void intensity_network_stream::assembler_thread_main() {
 
     // We use try..catch to ensure that _assembler_thread_exit() always gets called, even if an exception is thrown.
     // We also print the exception so that it doesn't get "swallowed".
+
+    chime_log_set_thread_name("Assembler-" + std::to_string(ini_params.stream_id));
 
     try {
 	_assembler_thread_body();  // calls pin_thread_to_cores()

--- a/intensity_network_stream.cpp
+++ b/intensity_network_stream.cpp
@@ -514,6 +514,7 @@ intensity_network_stream::get_statistics() {
     m["nupfreq"]                = ini_params.nupfreq;
     m["nt_per_packet"]          = ini_params.nt_per_packet;
     m["fpga_counts_per_sample"] = ini_params.fpga_counts_per_sample;
+    m["frame0_nano"]            = frame0_nano;
     m["fpga_count"]             = 0;    // XXX FIXME XXX
     m["network_thread_waiting_usec"] = network_thread_waiting_usec;
     m["network_thread_working_usec"] = network_thread_working_usec;


### PR DESCRIPTION
- add frame0_nano to get_statistics results

Minor:
- sets thread names for chlog()
- quiets some of my excessive chatter retrieving the frame0_nano value
